### PR TITLE
1.3-BETA

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>de.eldoria</groupId>
   <artifactId>SchematicBrushReborn</artifactId>
-  <version>1.2-BETA</version>
+  <version>1.3-BETA</version>
   <build>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.eldoria</groupId>
     <artifactId>SchematicBrushReborn</artifactId>
-    <version>1.2-BETA</version>
+    <version>1.3-BETA</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/de/eldoria/schematicbrush/ConfigUpdater.java
+++ b/src/main/java/de/eldoria/schematicbrush/ConfigUpdater.java
@@ -58,6 +58,11 @@ public final class ConfigUpdater {
         setIfAbsent(config, "debug", false);
         ConfigurationSection sources = createSectionIfAbsent(config, "schematicSources.scanPathes");
         setIfAbsent(config, "selectorSettings.pathSeperator", "/");
+        String o = plugin.getConfig().getString("selectorSettings.pathSeperator");
+        if (o.length() != 1) {
+            plugin.getLogger().warning("Path seperator invalid. Must be only one char.");
+            plugin.getConfig().set("selectorSettings.pathSeperator", "/");
+        }
         setIfAbsent(config, "selectorSettings.pathSourceAsPrefix", false);
         setIfAbsent(config, "schematicSources.excludedPathes", Collections.singletonList("none"));
     }

--- a/src/main/java/de/eldoria/schematicbrush/SchematicBrushReborn.java
+++ b/src/main/java/de/eldoria/schematicbrush/SchematicBrushReborn.java
@@ -19,6 +19,7 @@ public class SchematicBrushReborn extends JavaPlugin {
     public static Logger logger() {
         return logger;
     }
+
     public static boolean debugMode() {
         return debug;
     }
@@ -28,8 +29,19 @@ public class SchematicBrushReborn extends JavaPlugin {
 
     }
 
-    public void onReload() {
-        schematics.reload();
+    public void reload() {
+        saveDefaultConfig();
+        this.reloadConfig();
+        ConfigUpdater.validateConfig(this);
+        debug = getConfig().getBoolean("debug");
+
+        if (schematics == null) {
+            schematics = new SchematicCache(this);
+            schematics.init();
+        } else {
+            schematics.reload();
+        }
+
     }
 
     @Override
@@ -43,14 +55,7 @@ public class SchematicBrushReborn extends JavaPlugin {
             return;
         }
 
-        saveDefaultConfig();
-
-        ConfigUpdater.validateConfig(this);
-
-        debug = getConfig().getBoolean("debug");
-
-        schematics = new SchematicCache(this);
-        schematics.init();
+        reload();
 
         BrushCommand brushCommand = new BrushCommand(this, schematics);
         BrushModifyCommand modifyCommand = new BrushModifyCommand(this, schematics);

--- a/src/main/java/de/eldoria/schematicbrush/commands/BrushAdminCommand.java
+++ b/src/main/java/de/eldoria/schematicbrush/commands/BrushAdminCommand.java
@@ -1,6 +1,7 @@
 package de.eldoria.schematicbrush.commands;
 
 import de.eldoria.schematicbrush.C;
+import de.eldoria.schematicbrush.SchematicBrushReborn;
 import de.eldoria.schematicbrush.commands.util.MessageSender;
 import de.eldoria.schematicbrush.commands.util.TabUtil;
 import de.eldoria.schematicbrush.schematics.SchematicCache;
@@ -9,7 +10,6 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginDescriptionFile;
 
 import java.util.Arrays;
@@ -18,12 +18,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class BrushAdminCommand implements TabExecutor {
-    private final Plugin plugin;
+    private final SchematicBrushReborn instance;
     private final SchematicCache cache;
     private static final String[] COMMANDS = {"info", "reload", "reloadschematics"};
 
-    public BrushAdminCommand(Plugin plugin, SchematicCache cache) {
-        this.plugin = plugin;
+    public BrushAdminCommand(SchematicBrushReborn instance,
+                             SchematicCache cache) {
+        this.instance = instance;
         this.cache = cache;
     }
 
@@ -70,12 +71,13 @@ public class BrushAdminCommand implements TabExecutor {
     }
 
     private void info(CommandSender sender) {
-        PluginDescriptionFile descr = plugin.getDescription();
+        PluginDescriptionFile descr = instance.getDescription();
         String info = "§bSchematic Brush Reborn§r by §b" + String.join(", ", descr.getAuthors()) + "§r" + C.NEW_LINE
                 + "§bVersion§r : " + descr.getVersion() + C.NEW_LINE
-                + "§bSpigot:§r " + descr.getWebsite();
+                + "§bSpigot:§r " + descr.getWebsite() + C.NEW_LINE
+                + "§bSupport:§r https://discord.gg/zRW9Vpu";
         if (sender instanceof ConsoleCommandSender) {
-            plugin.getLogger().info(info);
+            instance.getLogger().info(info);
         } else if (sender instanceof Player) {
             MessageSender.sendMessage((Player) sender, info);
         }
@@ -83,10 +85,9 @@ public class BrushAdminCommand implements TabExecutor {
     }
 
     private void reload(CommandSender sender) {
-        cache.reload();
-        plugin.reloadConfig();
+        instance.reload();
         if (sender instanceof ConsoleCommandSender) {
-            plugin.getLogger().info("Schematic Brush Reborn reloaded.");
+            instance.getLogger().info("Schematic Brush Reborn reloaded.");
         } else if (sender instanceof Player) {
             MessageSender.sendMessage((Player) sender, "Schematic Brush Reborn reloaded.");
         }
@@ -95,7 +96,7 @@ public class BrushAdminCommand implements TabExecutor {
     private void reloadSchematics(CommandSender sender) {
         cache.reload();
         if (sender instanceof ConsoleCommandSender) {
-            plugin.getLogger().info("Schematics reloaded.");
+            instance.getLogger().info("Schematics reloaded.");
         } else if (sender instanceof Player) {
             MessageSender.sendMessage((Player) sender, "Schematics reloaded");
         }

--- a/src/main/java/de/eldoria/schematicbrush/commands/BrushCommand.java
+++ b/src/main/java/de/eldoria/schematicbrush/commands/BrushCommand.java
@@ -93,10 +93,10 @@ public class BrushCommand implements TabExecutor, Randomable {
     @Override
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
         String last = args[args.length - 1];
-        if (TabUtil.isFlag(last)) {
+        if (TabUtil.isFlag(args)) {
             return TabUtil.getFlagComplete(last);
         }
 
-        return TabUtil.getSchematicSetSyntax(last, schematicCache, plugin);
+        return TabUtil.getSchematicSetSyntax(args, schematicCache, plugin);
     }
 }

--- a/src/main/java/de/eldoria/schematicbrush/commands/BrushModifyCommand.java
+++ b/src/main/java/de/eldoria/schematicbrush/commands/BrushModifyCommand.java
@@ -299,7 +299,7 @@ public class BrushModifyCommand implements TabExecutor, Randomable {
         }
 
         if ("append".equalsIgnoreCase(cmd) || "a".equalsIgnoreCase(cmd)) {
-            return TabUtil.getSchematicSetSyntax(last, schematicCache, plugin);
+            return TabUtil.getSchematicSetSyntax(args, schematicCache, plugin);
         }
 
         if ("remove".equalsIgnoreCase(cmd) || "r".equalsIgnoreCase(cmd)) {
@@ -319,7 +319,7 @@ public class BrushModifyCommand implements TabExecutor, Randomable {
             if (args.length == 2) {
                 return Collections.singletonList("<schematic set>");
             }
-            return TabUtil.getSchematicSetSyntax(last, schematicCache, plugin);
+            return TabUtil.getSchematicSetSyntax(args, schematicCache, plugin);
         }
 
         if ("info".equalsIgnoreCase(cmd) || "i".equalsIgnoreCase(cmd)) {

--- a/src/main/java/de/eldoria/schematicbrush/commands/SchematicPresetCommand.java
+++ b/src/main/java/de/eldoria/schematicbrush/commands/SchematicPresetCommand.java
@@ -472,7 +472,7 @@ public class SchematicPresetCommand implements TabExecutor {
                 }
                 return Collections.singletonList("<name of preset>");
             }
-            return TabUtil.getSchematicSetSyntax(last, schematicCache, plugin);
+            return TabUtil.getSchematicSetSyntax(args, schematicCache, plugin);
         }
 
         if ("appendSet".equalsIgnoreCase(cmd) || "ab".equalsIgnoreCase(cmd)) {
@@ -485,7 +485,7 @@ public class SchematicPresetCommand implements TabExecutor {
                 return TabUtil.getPresets(last, plugin, 50);
             }
 
-            return TabUtil.getSchematicSetSyntax(last, schematicCache, plugin);
+            return TabUtil.getSchematicSetSyntax(args, schematicCache, plugin);
         }
 
         if ("removeSet".equalsIgnoreCase(cmd) || "rb".equalsIgnoreCase(cmd)) {

--- a/src/main/java/de/eldoria/schematicbrush/commands/parser/BrushSettingsParser.java
+++ b/src/main/java/de/eldoria/schematicbrush/commands/parser/BrushSettingsParser.java
@@ -20,15 +20,21 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static de.eldoria.schematicbrush.commands.parser.ParsingUtil.parseToLegacySyntax;
+
 @UtilityClass
 public class BrushSettingsParser {
-    private final Pattern Y_OFFSET = Pattern.compile("-(?:(?:yoff)|(?:yoffset)|(?:y)):(-?[0-9]{1,3})$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern Y_OFFSET = Pattern.compile("-(?:(?:yoff)|(?:yoffset)|(?:y)):(-?[0-9]{1,3})$", Pattern.CASE_INSENSITIVE);
     private final Pattern PLACEMENT = Pattern.compile("-(?:(?:place)|(?:placement)|(?:p)):([a-zA-Z]+?)$", Pattern.CASE_INSENSITIVE);
+
+
 
     public Optional<BrushSettings> parseBrush(Player player, Plugin plugin, SchematicCache schematicCache,
                                               String[] args) {
+
+
         // Remove brush settings from arguments.
-        List<String> brushes = Arrays.stream(args).filter(c -> !c.startsWith("-")).collect(Collectors.toList());
+        List<String> brushes = Arrays.stream(parseToLegacySyntax(args)).filter(c -> !c.startsWith("-")).collect(Collectors.toList());
 
 
         Optional<BrushSettings.BrushSettingsBuilder> brushSettings = buildBrushes(player, brushes, plugin, schematicCache);
@@ -46,7 +52,6 @@ public class BrushSettingsParser {
      * @param settingsStrings one or more brushes
      * @param plugin          plugin instance
      * @param schematicCache  schematic cache instance
-
      * @return A optional, which returns a unconfigured {@link BrushSettings.BrushSettingsBuilder} with brushes already set
      * or empty if a brush string could not be parsed
      */
@@ -197,7 +202,6 @@ public class BrushSettingsParser {
     }
 
     /**
-
      * Build a new Brush from a {@link BrushSettings.BrushSettingsBuilder}
      *
      * @param player          executor of the brush

--- a/src/main/java/de/eldoria/schematicbrush/commands/parser/ParsingUtil.java
+++ b/src/main/java/de/eldoria/schematicbrush/commands/parser/ParsingUtil.java
@@ -1,0 +1,73 @@
+package de.eldoria.schematicbrush.commands.parser;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public final class ParsingUtil {
+    // Legacy pattern parser
+    private static final Pattern FLIP = Pattern.compile("-flip:|-f:", Pattern.CASE_INSENSITIVE);
+    private static final Pattern ROTATION = Pattern.compile("-rotate:|-r:", Pattern.CASE_INSENSITIVE);
+    private static final Pattern WEIGHT = Pattern.compile("-weight:|-w:", Pattern.CASE_INSENSITIVE);
+    private static final Pattern RANDOM = Pattern.compile(":random|:r", Pattern.CASE_INSENSITIVE);
+    private static final Pattern DIRECTORY = Pattern.compile("dir:|d:", Pattern.CASE_INSENSITIVE);
+    private static final Pattern PRESET = Pattern.compile("preset:|p:", Pattern.CASE_INSENSITIVE);
+    private static final Pattern REGEX = Pattern.compile("regex:|r:", Pattern.CASE_INSENSITIVE);
+
+    private ParsingUtil() {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+    }
+
+    public static String parseToLegacyModifier(String modifier) {
+        String result = modifier;
+        result = RANDOM.matcher(result).replaceAll(":*");
+        result = FLIP.matcher(result).replaceAll("!");
+        result = ROTATION.matcher(result).replaceAll("@");
+        return WEIGHT.matcher(result).replaceAll(":");
+    }
+
+    public static String parseToLegacySelector(String selector) {
+        String result = selector;
+        result = DIRECTORY.matcher(result).replaceAll("\\$");
+        result = PRESET.matcher(result).replaceAll("&");
+        return REGEX.matcher(result).replaceAll("\\^");
+    }
+
+    public static String[] parseToLegacySyntax(String[] args) {
+        List<String> parsedInput = new ArrayList<>();
+        boolean open = false;
+
+        StringBuilder argumentBuilder = new StringBuilder();
+        for (String arg : args) {
+            // If a string starts and ends with a double quote we assume, that a new schematic is defined inside
+            if (arg.startsWith("\"") && arg.endsWith("\"")) {
+                parsedInput.add(parseToLegacySelector(arg.substring(1, arg.length() - 1)));
+                continue;
+            }
+            // If a string starts with a double quote we assume, that a new schematic set will be defined and open the section
+            if (arg.startsWith("\"")) {
+                open = true;
+                argumentBuilder.append(parseToLegacySelector(arg.substring(1)));
+                continue;
+            }
+
+            // If a string starts with a double quote we assume, that a new schematic set was defined and close the section
+            if (arg.endsWith("\"")) {
+                open = false;
+                argumentBuilder.append(parseToLegacyModifier(arg.substring(0, arg.length() - 1)));
+                parsedInput.add(argumentBuilder.toString());
+                argumentBuilder.setLength(0);
+                continue;
+            }
+
+            // if the current section is not open we just add the input. Could be a flagt or legacy syntax
+            if (!open) {
+                parsedInput.add(arg);
+                continue;
+            }
+            // if the current section is open, we keep appending all arguments.
+            argumentBuilder.append(parseToLegacyModifier(arg));
+        }
+        return parsedInput.toArray(new String[0]);
+    }
+}

--- a/src/main/java/de/eldoria/schematicbrush/commands/util/MessageSender.java
+++ b/src/main/java/de/eldoria/schematicbrush/commands/util/MessageSender.java
@@ -1,20 +1,22 @@
 package de.eldoria.schematicbrush.commands.util;
 
-import lombok.experimental.UtilityClass;
 import org.bukkit.entity.Player;
 
-@UtilityClass
-public class MessageSender {
-    private final String PREFIX = "§6[SB] ";
-    private final String DEFAULT_MESSAGE_COLOR = "§r§2";
-    private final String DEFAULT_ERROR_COLOR = "§r§c";
+public final class MessageSender {
+    private static final String PREFIX = "§6[SB] ";
+    private static final String DEFAULT_MESSAGE_COLOR = "§r§2";
+    private static final String DEFAULT_ERROR_COLOR = "§r§c";
+
+    private MessageSender() {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+    }
 
     /**
      * Send a message to a player
      * @param player receiver of the message
      * @param message message with optinal color codes
      */
-    public void sendMessage(Player player, String message) {
+    public static void sendMessage(Player player, String message) {
         player.sendMessage(PREFIX + DEFAULT_MESSAGE_COLOR + message.replaceAll("§r", DEFAULT_MESSAGE_COLOR));
     }
 
@@ -23,7 +25,7 @@ public class MessageSender {
      * @param player receiver of the message
      * @param message message with optinal color codes
      */
-    public void sendError(Player player, String message) {
+    public static void sendError(Player player, String message) {
         player.sendMessage(PREFIX + DEFAULT_MESSAGE_COLOR + message.replaceAll("§r", DEFAULT_ERROR_COLOR));
     }
 }

--- a/src/main/java/de/eldoria/schematicbrush/commands/util/TabUtil.java
+++ b/src/main/java/de/eldoria/schematicbrush/commands/util/TabUtil.java
@@ -2,7 +2,6 @@ package de.eldoria.schematicbrush.commands.util;
 
 import de.eldoria.schematicbrush.schematics.SchematicCache;
 import de.eldoria.schematicbrush.util.ArrayUtil;
-import lombok.experimental.UtilityClass;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.plugin.Plugin;
 
@@ -14,24 +13,99 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@UtilityClass
-public class TabUtil {
-    private final String[] INCLUDE_AIR = {"-includeair", "-incair", "-a"};
-    private final String[] REPLACE_ALL = {"-replaceAll", "-repla", "-r"};
+import static de.eldoria.schematicbrush.util.TextUtil.countChars;
 
-    private final String[] Y_OFFSET = {"-yoffset:", "-yoff:", "-y:"};
-    private final String[] PLACEMENT = {"-placement:", "-place:", "-p:"};
+public final class TabUtil {
+    private static final String[] INCLUDE_AIR = {"-includeair", "-incair", "-a"};
+    private static final String[] REPLACE_ALL = {"-replaceAll", "-repla", "-r"};
+
+    private static final String[] Y_OFFSET = {"-yoffset:", "-yoff:", "-y:"};
+    private static final String[] PLACEMENT = {"-placement:", "-place:", "-p:"};
 
 
-    private final String[] SMALL_FLAGS = {INCLUDE_AIR[0], REPLACE_ALL[0], Y_OFFSET[0], PLACEMENT[0]};
-    private final String[] FLAGS = ArrayUtil.combineArrays(INCLUDE_AIR, REPLACE_ALL, Y_OFFSET, PLACEMENT);
+    private static final String[] SMALL_FLAGS = {INCLUDE_AIR[0], REPLACE_ALL[0], Y_OFFSET[0], PLACEMENT[0]};
+    private static final String[] FLAGS = ArrayUtil.combineArrays(INCLUDE_AIR, REPLACE_ALL, Y_OFFSET, PLACEMENT);
 
-    private final String[] PLACEMENT_TYPES = {"middle", "bottom", "top", "drop", "raise"};
+    private static final String[] PLACEMENT_TYPES = {"middle", "bottom", "top", "drop", "raise"};
 
-    private final String[] FLIP_TYPES = {"N", "W", "NS", "WE", "*"};
-    private final String[] ROTATION_TYPES = {"0", "90", "180", "270", "*"};
+    private static final String[] FLIP_TYPES = {"N", "W", "NS", "WE", "*"};
+    private static final String[] ROTATION_TYPES = {"90", "180", "270", "*"};
 
-    private final char[] MARKER = {':', '@', '!', '^', '$', '&'};
+    private static final String[] SELECTOR_TYPE = {"<name>", "dir:", "regex:", "preset:"};
+    private static final String[] SELECTOR_TYPE_MATCH = {"dir:", "d:", "regex:", "r:", "preset:", "p:"};
+
+    private static final String[] MODIFIERS = {"-flip:", "-rotate:", "-weight:", "-f:", "-r:", "-w:"};
+
+    private static final String[] ROTATION = {"90", "180", "270", "random"};
+    private static final String[] FLIP = {"N", "E", "random"};
+
+    private static final char[] MARKER = {':', '@', '!', '^', '$', '&'};
+
+    private TabUtil() {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+    }
+
+    public static List<String> getSchematicSetSyntax(String[] args, SchematicCache cache, Plugin plugin) {
+        int quoteCount = countChars(String.join(" ", args), '\"');
+        String last = args[args.length - 1];
+        if (quoteCount % 2 == 0) {
+            return getLegacySchematicSetSyntax(last, cache, plugin);
+        }
+
+        return getSchematicSetSyntax(last, cache, plugin);
+    }
+
+    private static List<String> getSchematicSetSyntax(String arg, SchematicCache cache, Plugin plugin) {
+        if (arg.startsWith("\"")) {
+            if ("\"".equals(arg)) {
+                return prefixStrings(Arrays.asList(SELECTOR_TYPE), "\"");
+            }
+
+            String selector = arg.substring(1).toLowerCase();
+            String[] split = arg.split(":");
+
+            if (selector.startsWith("dir:") || selector.startsWith("d:")) {
+                List<String> matchingDirectories = cache.getMatchingDirectories(split.length == 1 ? "" : split[1], 50);
+                return prefixStrings(matchingDirectories, split[0] + ":");
+            }
+
+            if (selector.startsWith("preset:") || selector.startsWith("p:")) {
+                List<String> presets = getPresets(split.length == 1 ? "" : split[1], plugin, 50);
+                return prefixStrings(presets, split[0] + ":");
+            }
+
+            if (selector.startsWith("regex:") || selector.startsWith("r:")) {
+                return Collections.singletonList(selector + "<regex>");
+            }
+
+            List<String> matches = startingWithInArray(selector, SELECTOR_TYPE).collect(Collectors.toList());
+            matches.addAll(cache.getMatchingSchematics(selector, 50));
+            Collections.reverse(matches);
+            return prefixStrings(matches, "\"");
+        }
+
+        String[] split = arg.split(":");
+
+        if (arg.startsWith("-rotate:") || arg.startsWith("-r:")) {
+            if (split.length == 1) {
+                return prefixStrings(Arrays.asList(ROTATION), split[0] + ":");
+            }
+            return prefixStrings(startingWithInArray(split[1], ROTATION).collect(Collectors.toList()), split[0] + ":");
+        }
+
+        if (arg.startsWith("-flip:") || arg.startsWith("-f:")) {
+            if (split.length == 1) {
+                return prefixStrings(Arrays.asList(FLIP), split[0] + ":");
+            }
+            return prefixStrings(startingWithInArray(split[1], FLIP).collect(Collectors.toList()), split[0] + ":");
+        }
+
+        if (arg.startsWith("-weight:") || arg.startsWith("-w:")) {
+            return Collections.singletonList(split[0] + ":<number>");
+        }
+
+        return startingWithInArray(arg, MODIFIERS).collect(Collectors.toList());
+    }
 
     /**
      * Get the brush syntax for the current entry.
@@ -41,13 +115,13 @@ public class TabUtil {
      * @param plugin plugin for config access
      * @return a list of possible completions
      */
-    public List<String> getSchematicSetSyntax(String arg, SchematicCache cache, Plugin plugin) {
+    private static List<String> getLegacySchematicSetSyntax(String arg, SchematicCache cache, Plugin plugin) {
         Optional<Character> brushArgumentMarker = getBrushArgumentMarker(arg);
 
         if (arg.isEmpty()) {
             return Arrays.asList("<name>@rotation!flip:weight",
                     "$<directory>@rotation!flip:weight",
-                    "&<presetname>@rotation!flip:weight",
+                    "&<presetname>",
                     "^<regex>@rotation!flip:weight");
         }
 
@@ -78,24 +152,25 @@ public class TabUtil {
             case '^':
                 return Arrays.asList("^<regex>@rotation!flip:weight", arg + "@", arg + "!", arg + ":");
             case '$': {
-                List<String> matchingDirectories = cache.getMatchingDirectories(arg.substring(1), 50);
+                String directory = arg.substring(1);
+                List<String> matchingDirectories = cache.getMatchingDirectories(directory, 50);
                 matchingDirectories = prefixStrings(matchingDirectories, "$");
-                if (matchingDirectories.size() < 5) {
+                // only if a direct match is found add schematic arguments.
+                if (matchingDirectories.stream().anyMatch(d -> d.equalsIgnoreCase(directory)) || directory.endsWith("*")) {
                     matchingDirectories.addAll(getMissingSchematicSetArguments(arg));
-                    Collections.reverse(matchingDirectories);
                 } else {
                     matchingDirectories.add("$<directory>@rotation!flip:weight");
                 }
                 return matchingDirectories;
             }
             case '&': {
-                List<String> presets = getPresets(arg.substring(1), plugin, 50);
+                String preset = arg.substring(1);
+                List<String> presets = getPresets(preset, plugin, 50);
                 presets = prefixStrings(presets, "&");
-                if (presets.size() < 5) {
-                    presets.addAll(getMissingSchematicSetArguments(arg));
+                if (presets.size() < 1) {
                     Collections.reverse(presets);
                 } else {
-                    presets.add("&<preset>@rotation!flip:weight");
+                    presets.add("&<preset>");
                 }
                 return presets;
             }
@@ -109,17 +184,21 @@ public class TabUtil {
      * @param arg argument to check
      * @return true if the argument is a flag
      */
-    public boolean isFlag(String arg) {
-        return arg.startsWith("-");
+    public static boolean isFlag(String[] arg) {
+        if (countChars(String.join(" ", arg), '"') % 2 == 0) {
+            return arg[arg.length - 1].startsWith("-");
+
+        }
+        return false;
     }
 
     /**
-     * Get a tab complete for a flag. This will fail if {@link #isFlag(String)} is false.
+     * Get a tab complete for a flag. This will fail if {@link #isFlag(String[])} is false.
      *
      * @param flag flag to check
      * @return list of possible completions
      */
-    public List<String> getFlagComplete(String flag) {
+    public static List<String> getFlagComplete(String flag) {
         if (stringStartingWithValueInArray(flag, PLACEMENT)) {
             String[] split = flag.split(":");
             if (split.length == 1) {
@@ -149,7 +228,7 @@ public class TabUtil {
      * @param array array to check
      * @return list of strings which starts with the provided value
      */
-    public Stream<String> startingWithInArray(String value, String[] array) {
+    public static Stream<String> startingWithInArray(String value, String[] array) {
         return Arrays.stream(array).filter(e -> e.startsWith(value));
     }
 
@@ -160,7 +239,7 @@ public class TabUtil {
      * @param array array values.
      * @return true if the value starts with any value in the array
      */
-    public boolean stringStartingWithValueInArray(String value, String[] array) {
+    public static boolean stringStartingWithValueInArray(String value, String[] array) {
         return Arrays.stream(array).anyMatch(value::startsWith);
     }
 
@@ -171,7 +250,7 @@ public class TabUtil {
      * @param array array values.
      * @return true if the value ends with any value in the array
      */
-    public boolean endingWithInArray(String value, String[] array) {
+    public static boolean endingWithInArray(String value, String[] array) {
         return Arrays.stream(array).anyMatch(value::endsWith);
     }
 
@@ -181,7 +260,7 @@ public class TabUtil {
      * @param string string to check
      * @return optional argument marker if one is found.
      */
-    private Optional<Character> getBrushArgumentMarker(String string) {
+    private static Optional<Character> getBrushArgumentMarker(String string) {
         for (int i = string.length() - 1; i >= 0; i--) {
             char c = string.charAt(i);
             if (ArrayUtil.arrayContains(MARKER, c)) {
@@ -197,7 +276,7 @@ public class TabUtil {
      * @param string string to check
      * @return substring between end and last argument marker.
      */
-    private String getBrushArgumentStringToLastMarker(String string) {
+    private static String getBrushArgumentStringToLastMarker(String string) {
         for (int i = string.length() - 1; i >= 0; i--) {
             char c = string.charAt(i);
             if (ArrayUtil.arrayContains(MARKER, c)) {
@@ -215,7 +294,7 @@ public class TabUtil {
      * @param count  number of max returned preset names
      * @return list of matchin presets of length count or shorter.
      */
-    public List<String> getPresets(String arg, Plugin plugin, int count) {
+    public static List<String> getPresets(String arg, Plugin plugin, int count) {
         ConfigurationSection presets = plugin.getConfig().getConfigurationSection("presets");
         if (presets == null) {
             return new ArrayList<>(Collections.singletonList("Preset section missing in config!"));
@@ -223,9 +302,14 @@ public class TabUtil {
         if (presets.getKeys(false).isEmpty()) {
             return new ArrayList<>(Collections.singletonList("No presets defined!"));
         }
+        List<String> strings;
         String[] array = new String[presets.getKeys(false).size()];
-        List<String> strings = startingWithInArray(arg, presets.getKeys(false).toArray(array))
-                .collect(Collectors.toList());
+        if (arg.isEmpty()) {
+            strings = new ArrayList<>(presets.getKeys(false));
+        } else {
+            strings = startingWithInArray(arg, presets.getKeys(false).toArray(array))
+                    .collect(Collectors.toList());
+        }
         return strings.subList(0, Math.min(strings.size(), count));
     }
 
@@ -236,7 +320,7 @@ public class TabUtil {
      * @param prefix prefix to add
      * @return list of strings which start with the prefix
      */
-    private List<String> prefixStrings(List<String> list, String prefix) {
+    private static List<String> prefixStrings(List<String> list, String prefix) {
         return list.stream().map(s -> prefix + s).collect(Collectors.toList());
     }
 
@@ -246,7 +330,9 @@ public class TabUtil {
      * @param arg argument to check
      * @return list of missing arguments
      */
-    private List<String> getMissingSchematicSetArguments(String arg) {
+    private static List<String> getMissingSchematicSetArguments(String arg) {
+        // A preset cant have modifiers.
+        if (arg.startsWith("&")) return Collections.emptyList();
         List<String> result = new ArrayList<>();
         StringBuilder explanation = new StringBuilder();
         if (!arg.contains("@")) {
@@ -266,4 +352,5 @@ public class TabUtil {
         }
         return result;
     }
+
 }

--- a/src/main/java/de/eldoria/schematicbrush/util/TextUtil.java
+++ b/src/main/java/de/eldoria/schematicbrush/util/TextUtil.java
@@ -1,0 +1,14 @@
+package de.eldoria.schematicbrush.util;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public final class TextUtil {
+    public static int countChars(String string, char count) {
+        int i = 0;
+        for (char c : string.toCharArray()) {
+            if (c == count) i++;
+        }
+        return i;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,4 @@
+# Never change this!
 version: 2
 # Enable to get more information in our server console
 debug: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,11 +1,11 @@
 name: SchematicBrushReborn
-version: 1.2-BETA
+version: 1.3-BETA
 api-version: "1.13"
 depend:
   - "WorldEdit"
 main: de.eldoria.schematicbrush.SchematicBrushReborn
 authors: [Hadde, SirYwell]
-website: "https://www.spigotmc.org/resources/schematic-brush-reborn.79441/"
+website: "https://www.spigotmc.org/resources/79441/"
 commands:
   schematicbrushadmin:
     description: Manage schematic brush
@@ -17,6 +17,7 @@ commands:
     aliases:
       - sbr
       - schbr
+      - schembrush
     permission: "schematicbrush.brush.use"
     permission-message: "You dont have the permission to do this!"
   schematicbrushmodify:

--- a/src/main/test/de/eldoria/schematicbrush/commands/parser/ParsingUtilTest.java
+++ b/src/main/test/de/eldoria/schematicbrush/commands/parser/ParsingUtilTest.java
@@ -1,0 +1,30 @@
+package de.eldoria.schematicbrush.commands.parser;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ParsingUtilTest {
+    @Test
+    public void legacySelectorParserTest() {
+        Assert.assertEquals("$test", ParsingUtil.parseToLegacySelector("dir:test"));
+        Assert.assertEquals("$test*", ParsingUtil.parseToLegacySelector("dir:test*"));
+        Assert.assertEquals("^test.+?", ParsingUtil.parseToLegacySelector("regex:test.+?"));
+        Assert.assertEquals("&test", ParsingUtil.parseToLegacySelector("preset:test"));
+        Assert.assertEquals("test", ParsingUtil.parseToLegacySelector("test"));
+    }
+
+    @Test
+    public void legacyModifierParserTest() {
+        Assert.assertEquals("@180", ParsingUtil.parseToLegacyModifier("-rotate:180"));
+        Assert.assertEquals("@*", ParsingUtil.parseToLegacyModifier("-rotate:random"));
+        Assert.assertEquals("!NS", ParsingUtil.parseToLegacyModifier("-flip:NS"));
+        Assert.assertEquals("!N", ParsingUtil.parseToLegacyModifier("-flip:N"));
+        Assert.assertEquals(":10", ParsingUtil.parseToLegacyModifier("-weight:10"));
+    }
+
+    @Test
+    public void legaceSchematicSetParserTest() {
+        Assert.assertEquals("&test@180:10", ParsingUtil.parseToLegacySyntax(new String[] {"\"p:test", "-rotate:180", "-weight:10\""})[0]);
+        Assert.assertEquals("&test@180!NE", ParsingUtil.parseToLegacySyntax(new String[] {"\"p:test", "-rotate:180","-flip:NE\""})[0]);
+    }
+}


### PR DESCRIPTION
This patch is a improvement patch.

I added a alternative syntax to define schematic sets, which will be parsed into the old legacy syntax. Unfortunately i cant really simplify this system due it's high complexity without removing some features.
The new alternative syntax is way more readable for you. But still features all functions of the old known legacy syntax.

I also improved the tab completion when you type a directory. Instead of listing all directories i only list the folders in the current hierarchy. This makes it more easy to navigate though your folders.

Also the need to manually reload the plugin to use recently added schematics was some kind of lazy implementation. I still need to cache the schematics to ensure, that I don't have to search for a fitting schematic every time, but i added a reload of the schematics every minute. Don't worry this wont cause any lags on your server and will be executed in a separate thread. So now every minute we will add your new schematics to the cache. Of course u can still use the current reload schematics command if you are in a hurry.