### PR TITLE
Fix/watch service cpu usage

### DIFF
--- a/.github/workflows/publish_to_nexus.yml
+++ b/.github/workflows/publish_to_nexus.yml
@@ -8,6 +8,7 @@ on:
       - dev*
       - feature/*
       - release/*
+      - fix/*
 
 jobs:
   build:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = "de.eldoria"
-version = "1.4.3"
+version = "1.4.4"
 description = "SchematicBrushReborn"
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 val shadebase = "de.eldoria.schematicbrush."


### PR DESCRIPTION
Fixes high cpu usage cause by the file watcher.

The watcher was permanently checking for updates instead of waiting for updates