### PR TITLE
Fix rendering on fawe

### DIFF
--- a/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/event/PostPasteEvent.java
+++ b/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/event/PostPasteEvent.java
@@ -1,3 +1,9 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2021 EldoriaRPG Team und Contributor
+ */
+
 package de.eldoria.schematicbrush.event;
 
 import de.eldoria.schematicbrush.schematics.Schematic;

--- a/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/event/PostPasteEvent.java
+++ b/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/event/PostPasteEvent.java
@@ -1,0 +1,53 @@
+package de.eldoria.schematicbrush.event;
+
+import de.eldoria.schematicbrush.schematics.Schematic;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A paste event.
+ * The event may be asynchronous.
+ */
+@SuppressWarnings({"unused", "SameReturnValue"})
+public class PostPasteEvent extends Event {
+    public static final HandlerList HANDLERS = new HandlerList();
+    private final Player who;
+    private final Schematic schematic;
+
+    public PostPasteEvent(@NotNull Player who, Schematic schematic) {
+        super(!Bukkit.isPrimaryThread());
+        this.who = who;
+        this.schematic = schematic;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+    /**
+     * Player who pasted
+     *
+     * @return player
+     */
+    public Player player() {
+        return who;
+    }
+
+    /**
+     * The pasted schematic
+     *
+     * @return schematic
+     */
+    public Schematic schematic() {
+        return schematic;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+}

--- a/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/event/PrePasteEvent.java
+++ b/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/event/PrePasteEvent.java
@@ -1,3 +1,9 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2021 EldoriaRPG Team und Contributor
+ */
+
 package de.eldoria.schematicbrush.event;
 
 import de.eldoria.schematicbrush.schematics.Schematic;

--- a/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/event/PrePasteEvent.java
+++ b/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/event/PrePasteEvent.java
@@ -1,0 +1,53 @@
+package de.eldoria.schematicbrush.event;
+
+import de.eldoria.schematicbrush.schematics.Schematic;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A paste event.
+ * The event may be asynchronous.
+ */
+@SuppressWarnings({"unused", "SameReturnValue"})
+public class PrePasteEvent extends Event {
+    public static final HandlerList HANDLERS = new HandlerList();
+    private final Player who;
+    private final Schematic schematic;
+
+    public PrePasteEvent(@NotNull Player who, Schematic schematic) {
+        super(!Bukkit.isPrimaryThread());
+        this.who = who;
+        this.schematic = schematic;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+    /**
+     * Player who pasted
+     *
+     * @return player
+     */
+    public Player player() {
+        return who;
+    }
+
+    /**
+     * The pasted schematic
+     *
+     * @return schematic
+     */
+    public Schematic schematic() {
+        return schematic;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+}

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/SchematicBrushImpl.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/SchematicBrushImpl.java
@@ -22,6 +22,8 @@ import de.eldoria.schematicbrush.brush.config.BrushSettings;
 import de.eldoria.schematicbrush.brush.config.BrushSettingsRegistry;
 import de.eldoria.schematicbrush.brush.config.builder.BrushBuilder;
 import de.eldoria.schematicbrush.event.PasteEvent;
+import de.eldoria.schematicbrush.event.PostPasteEvent;
+import de.eldoria.schematicbrush.event.PrePasteEvent;
 import de.eldoria.schematicbrush.rendering.BlockChangeCollector;
 import de.eldoria.schematicbrush.rendering.CapturingExtent;
 import de.eldoria.schematicbrush.rendering.CapturingExtentImpl;
@@ -65,9 +67,10 @@ public class SchematicBrushImpl implements SchematicBrush {
     private void paste(EditSession editSession, BlockVector3 position) {
         var paste = nextPaste.buildpaste(editSession, BukkitAdapter.adapt(brushOwner), position);
 
-        Operations.completeBlindly(paste);
         if (editSession.getWorld() instanceof FakeWorldImpl) return;
-        plugin.getServer().getPluginManager().callEvent(new PasteEvent(brushOwner, nextPaste.schematic()));
+        plugin.getServer().getPluginManager().callEvent(new PrePasteEvent(brushOwner, nextPaste.schematic()));
+        Operations.completeBlindly(paste);
+        plugin.getServer().getPluginManager().callEvent(new PostPasteEvent(brushOwner, nextPaste.schematic()));
         buildNextPaste();
     }
 

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/commands/settings/Preview.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/commands/settings/Preview.java
@@ -34,10 +34,6 @@ public class Preview extends AdvancedCommand implements IPlayerTabExecutor {
 
     @Override
     public void onCommand(@NotNull Player player, @NotNull String alias, @NotNull Arguments args) throws CommandException {
-        if (!renderService.isActive()) {
-            messageSender().sendMessage(player, "The preview can not be used with fawe.");
-            return;
-        }
         var state = args.asBoolean(0);
         renderService.setState(player, state);
         if (state) {

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/rendering/RenderService.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/rendering/RenderService.java
@@ -42,6 +42,9 @@ public class RenderService implements Runnable, Listener {
      * The players which should receive render preview packets
      */
     private final Queue<Player> players = new ArrayDeque<>();
+    /**
+     * Players which should be excluded from receiving render packets.
+     */
     private final Set<UUID> skip = new HashSet<>();
     private final Plugin plugin;
     private final Configuration configuration;
@@ -86,6 +89,7 @@ public class RenderService implements Runnable, Listener {
 
     @Override
     public void run() {
+        if(players.isEmpty()) return;
         count += players.size() / (double) configuration.general().previewRefreshInterval();
         var start = System.currentTimeMillis();
         while (count > 0 && !players.isEmpty() && System.currentTimeMillis() - start < configuration.general().maxRenderMs()) {

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/rendering/RenderService.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/rendering/RenderService.java
@@ -8,6 +8,8 @@ package de.eldoria.schematicbrush.rendering;
 
 import de.eldoria.schematicbrush.config.Configuration;
 import de.eldoria.schematicbrush.event.PasteEvent;
+import de.eldoria.schematicbrush.event.PostPasteEvent;
+import de.eldoria.schematicbrush.event.PrePasteEvent;
 import de.eldoria.schematicbrush.util.WorldEditBrush;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -16,34 +18,44 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayDeque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.Set;
 import java.util.UUID;
 
 public class RenderService implements Runnable, Listener {
+    /**
+     * The changes which were send to the player lately
+     */
     private final Map<UUID, Changes> changes = new HashMap<>();
+    /**
+     * The paket worker which will process packet sending to players
+     */
     private final PaketWorker worker;
+    /**
+     * The players which should receive render preview packets
+     */
     private final Queue<Player> players = new ArrayDeque<>();
+    private final Set<UUID> skip = new HashSet<>();
+    private final Plugin plugin;
     private final Configuration configuration;
     private double count = 1;
-    private boolean active = false;
 
     public RenderService(Plugin plugin, Configuration configuration) {
+        this.plugin = plugin;
         this.configuration = configuration;
-        active = !plugin.getServer().getPluginManager().isPluginEnabled("FastAsyncWorldEdit");
         worker = new PaketWorker();
-        if (active) {
             worker.runTaskTimerAsynchronously(plugin, 0, 1);
-        }
     }
 
     @EventHandler
     public void onJoin(PlayerJoinEvent event) {
-        if (!active) return;
         if (event.getPlayer().hasPermission("schematicbrush.brush.preview")) {
             if (configuration.general().isPreviewDefault()) {
                 setState(event.getPlayer(), true);
@@ -57,25 +69,31 @@ public class RenderService implements Runnable, Listener {
     }
 
     @EventHandler
-    public void onPaste(PasteEvent event) {
-        if (!active) return;
+    public void onPaste(PrePasteEvent event) {
+        skip.add(event.player().getUniqueId());
+    }
+
+    @EventHandler
+    public void onPostPaste(PostPasteEvent event) {
         worker.remove(event.player());
         changes.remove(event.player().getUniqueId());
         var schematicBrush = WorldEditBrush.getSchematicBrush(event.player());
         if (schematicBrush.isEmpty()) return;
         var collector = schematicBrush.get().pasteFake();
         worker.queue(event.player(), null, collector.changes());
+        plugin.getServer().getScheduler().runTaskLater(plugin, () -> skip.remove(event.player().getUniqueId()), 20);
     }
 
     @Override
     public void run() {
-        if (!active) return;
         count += players.size() / (double) configuration.general().previewRefreshInterval();
         var start = System.currentTimeMillis();
         while (count > 0 && !players.isEmpty() && System.currentTimeMillis() - start < configuration.general().maxRenderMs()) {
             count--;
-            var player = players.poll();
-            render(player);
+            var player = players.remove();
+            if (!skip.contains(player.getUniqueId())) {
+                render(player);
+            }
             players.add(player);
         }
     }
@@ -112,7 +130,6 @@ public class RenderService implements Runnable, Listener {
     }
 
     public void setState(Player player, boolean state) {
-        if (!active) return;
         if (state) {
             if (players.contains(player)) {
                 return;
@@ -122,10 +139,6 @@ public class RenderService implements Runnable, Listener {
             players.remove(player);
             resolveChanges(player);
         }
-    }
-
-    public boolean isActive() {
-        return active;
     }
 
     private static class PaketWorker extends BukkitRunnable {


### PR DESCRIPTION
Fix the rendering on fawe.

This is done by blocking the rendering process for a few seconds when fawe pastes. This is highly based no the race condition that fawe will not take longer to write the changes to the world than the rendering is stopped.