### PR TITLE
Release 2.1.3

### DIFF
--- a/buildSrc/src/main/kotlin/de.eldoria.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/de.eldoria.java-conventions.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "de.eldoria"
-version = "2.1.2"
+version = "2.1.3"
 
 repositories {
     maven("https://eldonexus.de/repository/maven-public")

--- a/buildSrc/src/main/kotlin/de.eldoria.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/de.eldoria.java-conventions.gradle.kts
@@ -14,9 +14,9 @@ repositories {
 dependencies {
     compileOnly("org.spigotmc", "spigot-api", "1.16.5-R0.1-SNAPSHOT")
     compileOnly("org.jetbrains", "annotations", "20.1.0")
-    compileOnly("com.sk89q.worldedit", "worldedit-bukkit", "7.2.8")
-    compileOnly("com.fastasyncworldedit:FastAsyncWorldEdit-Core:2.0.0-SNAPSHOT")
-    compileOnly("com.fastasyncworldedit:FastAsyncWorldEdit-Bukkit:2.0.0-SNAPSHOT") { isTransitive = false }
+    compileOnly("com.sk89q.worldedit", "worldedit-bukkit", "7.2.10")
+    compileOnly("com.fastasyncworldedit:FastAsyncWorldEdit-Core:2.1.1-SNAPSHOT")
+    compileOnly("com.fastasyncworldedit:FastAsyncWorldEdit-Bukkit:2.1.1-SNAPSHOT") { isTransitive = false }
 
     testImplementation(platform("org.junit:junit-bom:5.7.2"))
     testImplementation("org.junit.jupiter:junit-jupiter")

--- a/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/config/sections/GeneralConfig.java
+++ b/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/config/sections/GeneralConfig.java
@@ -31,4 +31,6 @@ public interface GeneralConfig extends ConfigurationSerializable {
     int maxRenderSize();
 
     int renderDistance();
+
+    int maxeffectiveRenderSize();
 }

--- a/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/util/Clipboards.java
+++ b/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/util/Clipboards.java
@@ -1,0 +1,21 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2021 EldoriaRPG Team and Contributor
+ */
+
+package de.eldoria.schematicbrush.util;
+
+import com.sk89q.worldedit.math.BlockVector3;
+
+import java.util.Iterator;
+
+public final class Clipboards {
+    private Clipboards() {
+        throw new UnsupportedOperationException("This is a utility class.");
+    }
+
+    public static Iterator<BlockVector3> iterate(com.sk89q.worldedit.extent.clipboard.Clipboard clipboard){
+        return clipboard.getRegion().iterator();
+    }
+}

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/SchematicBrushRebornImpl.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/SchematicBrushRebornImpl.java
@@ -125,7 +125,7 @@ public class SchematicBrushRebornImpl extends SchematicBrushReborn {
     @Override
     public @NotNull EntryData[] getDebugInformations() {
         return new EntryData[]{new EntryData("Customer Data", UserData.get().asString()),
-                new EntryData("Performance", String.format("Render Time: %d ms%nRender Operation Queue: %s%nOperation Paket Count: %d",
+                new EntryData("Performance", String.format("Render Time: %s ms%nRender Operation Queue: %s%nOperation Paket Count: %s",
                         renderService.renderTimeAverage(), renderService.paketQueueSize(), renderService.paketQueuePaketCount()))};
     }
 

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/config/selector/DirectorySelector.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/config/selector/DirectorySelector.java
@@ -35,7 +35,7 @@ public class DirectorySelector extends BaseSelector {
     @NotNull
     public Map<String, Object> serialize() {
         return SerializationUtil.newBuilder(super.serialize())
-                .add("directory")
+                .add("directory", directory)
                 .build();
     }
 

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/config/sections/GeneralConfigImpl.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/config/sections/GeneralConfigImpl.java
@@ -23,6 +23,7 @@ public class GeneralConfigImpl implements GeneralConfig {
     private int previewRefreshInterval = 1;
     private int maxRenderMs = 25;
     private int maxRenderSize = 2500;
+    private int maxeffectiveRenderSize = maxRenderSize;
     private int renderDistance = 100;
 
     public GeneralConfigImpl() {
@@ -37,6 +38,7 @@ public class GeneralConfigImpl implements GeneralConfig {
         previewRefreshInterval = map.getValueOrDefault("previewRefreshInterval", 1);
         maxRenderMs = map.getValueOrDefault("maxRenderMs", 25);
         maxRenderSize = map.getValueOrDefault("maxRenderSize", 2500);
+        maxeffectiveRenderSize = map.getValueOrDefault("maxeffectiveRenderSize", maxRenderSize);
         renderDistance = map.getValueOrDefault("renderDistance", 100);
     }
 
@@ -92,5 +94,10 @@ public class GeneralConfigImpl implements GeneralConfig {
     @Override
     public int renderDistance() {
         return renderDistance;
+    }
+
+    @Override
+    public int maxeffectiveRenderSize() {
+        return maxeffectiveRenderSize;
     }
 }

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/schematics/SchematicBrushCache.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/schematics/SchematicBrushCache.java
@@ -11,6 +11,7 @@ import de.eldoria.schematicbrush.SchematicBrushRebornImpl;
 import de.eldoria.schematicbrush.config.Configuration;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;


### PR DESCRIPTION
- Fixed a bug which occurred when saving a preset with a directory selector
- Added a `effectiveRenderSize` option. This option defines how many non air blocks are rendered when the brush does not include air when pasting. This mainly replaces the old mechanism of schematic size detection and will allow to render more schematics with a better performance estimation.