### PR TITLE
Development

### DIFF
--- a/buildSrc/src/main/kotlin/de.eldoria.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/de.eldoria.java-conventions.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "de.eldoria"
-version = "2.1.5"
+version = "2.1.6"
 
 repositories {
     maven("https://eldonexus.de/repository/maven-public")

--- a/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/config/sections/GeneralConfig.java
+++ b/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/config/sections/GeneralConfig.java
@@ -32,5 +32,5 @@ public interface GeneralConfig extends ConfigurationSerializable {
 
     int renderDistance();
 
-    int maxeffectiveRenderSize();
+    int maxEffectiveRenderSize();
 }

--- a/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/rendering/Changes.java
+++ b/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/rendering/Changes.java
@@ -6,7 +6,11 @@
 
 package de.eldoria.schematicbrush.rendering;
 
+import org.bukkit.Location;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Player;
+
+import java.util.Map;
 
 /**
  * A class to manage changes and send them to a player.
@@ -31,4 +35,12 @@ public interface Changes {
      * @return changes
      */
     int size();
+
+    void hide(Player player, Changes newChanges);
+
+    Map<Location, BlockData> changed();
+
+    Map<Location, BlockData> original();
+
+    void show(Player player, Changes oldChanges);
 }

--- a/schematicbrushreborn-core/build.gradle.kts
+++ b/schematicbrushreborn-core/build.gradle.kts
@@ -53,7 +53,7 @@ tasks {
         destinationDir = File(path.toString())
     }
 
-    build{
+    build {
         dependsOn(shadowJar)
     }
 }

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/config/replaceall/ReplaceAll.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/config/replaceall/ReplaceAll.java
@@ -7,6 +7,7 @@
 package de.eldoria.schematicbrush.brush.config.replaceall;
 
 import com.sk89q.worldedit.function.mask.BlockTypeMask;
+import com.sk89q.worldedit.function.mask.Masks;
 import com.sk89q.worldedit.world.block.BlockTypes;
 import de.eldoria.eldoutilities.serialization.SerializationUtil;
 import de.eldoria.schematicbrush.brush.PasteMutation;
@@ -48,12 +49,13 @@ public class ReplaceAll implements Mutator<Boolean> {
                 mutation.session().setMask(
                         new BlockTypeMask(mutation.session(), BlockTypes.AIR, BlockTypes.VOID_AIR, BlockTypes.CAVE_AIR));
             }
+        } else {
+            mutation.session().setMask(Masks.alwaysTrue());
         }
     }
 
     @Override
     public void value(Boolean value) {
-
     }
 
     @Override

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/config/sections/GeneralConfigImpl.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/config/sections/GeneralConfigImpl.java
@@ -23,7 +23,7 @@ public class GeneralConfigImpl implements GeneralConfig {
     private int previewRefreshInterval = 1;
     private int maxRenderMs = 25;
     private int maxRenderSize = 2500;
-    private int maxeffectiveRenderSize = maxRenderSize;
+    private int maxEffectiveRenderSize = maxRenderSize;
     private int renderDistance = 100;
 
     public GeneralConfigImpl() {
@@ -38,7 +38,7 @@ public class GeneralConfigImpl implements GeneralConfig {
         previewRefreshInterval = map.getValueOrDefault("previewRefreshInterval", 1);
         maxRenderMs = map.getValueOrDefault("maxRenderMs", 25);
         maxRenderSize = map.getValueOrDefault("maxRenderSize", 2500);
-        maxeffectiveRenderSize = map.getValueOrDefault("maxeffectiveRenderSize", maxRenderSize);
+        maxEffectiveRenderSize = map.getValueOrDefault("maxEffectiveRenderSize", maxRenderSize);
         renderDistance = map.getValueOrDefault("renderDistance", 100);
     }
 
@@ -52,6 +52,7 @@ public class GeneralConfigImpl implements GeneralConfig {
                 .add("previewRefreshInterval", previewRefreshInterval)
                 .add("maxRenderMs", maxRenderMs)
                 .add("maxRenderSize", maxRenderSize)
+                .add("maxEffectiveRenderSize", maxEffectiveRenderSize)
                 .add("renderDistance", renderDistance)
                 .build();
     }
@@ -97,7 +98,7 @@ public class GeneralConfigImpl implements GeneralConfig {
     }
 
     @Override
-    public int maxeffectiveRenderSize() {
-        return maxeffectiveRenderSize;
+    public int maxEffectiveRenderSize() {
+        return maxEffectiveRenderSize;
     }
 }

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/rendering/ChangesImpl.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/rendering/ChangesImpl.java
@@ -6,7 +6,6 @@
 
 package de.eldoria.schematicbrush.rendering;
 
-import org.antlr.v4.runtime.atn.PredicateTransition;
 import org.bukkit.Location;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.Player;
@@ -46,6 +45,30 @@ public class ChangesImpl implements Changes {
         for (var entry : data.entrySet()) {
             player.sendBlockChange(entry.getKey(), entry.getValue());
         }
+    }
+
+    @Override
+    public void show(Player player, Changes oldChanges) {
+        var filter  = new HashMap<>(changed);
+        filter.entrySet().removeIf(curr -> oldChanges.changed().get(curr.getKey()) == curr.getValue());
+        sendChanges(player, filter);
+    }
+
+    @Override
+    public void hide(Player player, Changes newChanges) {
+        var filter  = new HashMap<>(original);
+        filter.entrySet().removeIf(curr -> newChanges.changed().containsKey(curr.getKey()));
+        sendChanges(player, filter);
+    }
+
+    @Override
+    public Map<Location, BlockData> changed() {
+        return changed;
+    }
+
+    @Override
+    public Map<Location, BlockData> original() {
+        return original;
     }
 
     public static class Builder {

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/rendering/ChangesImpl.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/rendering/ChangesImpl.java
@@ -50,14 +50,18 @@ public class ChangesImpl implements Changes {
     @Override
     public void show(Player player, Changes oldChanges) {
         var filter  = new HashMap<>(changed);
-        filter.entrySet().removeIf(curr -> oldChanges.changed().get(curr.getKey()) == curr.getValue());
+        for (var entry : oldChanges.changed().entrySet()) {
+            filter.remove(entry.getKey(), entry.getValue());
+        }
         sendChanges(player, filter);
     }
 
     @Override
     public void hide(Player player, Changes newChanges) {
         var filter  = new HashMap<>(original);
-        filter.entrySet().removeIf(curr -> newChanges.changed().containsKey(curr.getKey()));
+        for (var location : newChanges.changed().keySet()) {
+            filter.remove(location);
+        }
         sendChanges(player, filter);
     }
 

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/rendering/RenderService.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/rendering/RenderService.java
@@ -194,13 +194,17 @@ public class RenderService implements Runnable, Listener {
 
     public static class PaketWorker extends BukkitRunnable {
         private final Queue<ChangeEntry> queue = new ArrayDeque<>();
+        private boolean active;
 
         @Override
         public void run() {
+            if(active) return;
+            active = true;
             while (!queue.isEmpty()) {
                 var poll = queue.poll();
                 poll.sendChanges();
             }
+            active = false;
         }
 
         public void queue(Player player, Changes oldChanges, Changes newChanges) {

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/rendering/RenderService.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/rendering/RenderService.java
@@ -141,7 +141,7 @@ public class RenderService implements Runnable, Listener {
             return;
         }
 
-        if (!includeAir && brush.nextPaste().schematic().effectiveSize() > configuration.general().maxeffectiveRenderSize()) {
+        if (!includeAir && brush.nextPaste().schematic().effectiveSize() > configuration.general().maxEffectiveRenderSize()) {
             resolveChanges(player);
             return;
         }
@@ -225,8 +225,17 @@ public class RenderService implements Runnable, Listener {
                                    Changes newChanges) {
 
             private void sendChanges() {
+                if (oldChanges != null && newChanges != null) {
+                    update();
+                    return;
+                }
                 if (oldChanges != null) oldChanges.hide(player);
                 if (newChanges != null) newChanges.show(player);
+            }
+
+            private void update() {
+                oldChanges.hide(player, newChanges);
+                newChanges.show(player, oldChanges);
             }
 
             public int size() {


### PR DESCRIPTION
- Fixed replace all setting not working after once set to false.
- Fixed a race condition in the preview when using large schematics
- Improved performance of the preview on client side. Tested with up to 32k blocks in preview
- Fixed the  `maxEffectiveRenderSize` not appearing in config file.