### PR TITLE
Feature/brush configs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "de.eldoria"
-version = "2.2.1"
+version = "2.2.2"
 
 subprojects {
     apply {

--- a/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/storage/base/Container.java
+++ b/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/storage/base/Container.java
@@ -9,12 +9,14 @@ package de.eldoria.schematicbrush.storage.base;
 import de.eldoria.eldoutilities.utils.Futures;
 import de.eldoria.schematicbrush.SchematicBrushReborn;
 import de.eldoria.schematicbrush.storage.ContainerPagedAccess;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
@@ -24,6 +26,8 @@ import java.util.logging.Level;
  * @param <T> Type of contained entries.
  */
 public interface Container<T> {
+    UUID GLOBAL = new UUID(0L, 0L);
+
     /**
      * Get a entry by name
      *
@@ -75,6 +79,25 @@ public interface Container<T> {
      * @return A future providing the size of the container.
      */
     CompletableFuture<Integer> size();
+
+    /**
+     * Get the owner of the container.
+     * <p>
+     * This might be the uuid of the owning player or {@link #GLOBAL} when it is a global container.
+     *
+     * @return owner uuid
+     */
+    @NotNull
+    UUID owner();
+
+    /**
+     * Checks if the {@link #owner()} is equal to {@link #GLOBAL}
+     *
+     * @return true if this container has the global UUID
+     */
+    default boolean isGlobalcontainer() {
+        return GLOBAL.equals(owner());
+    }
 
     /**
      * Migrate the container into this container.

--- a/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/util/WorldEditBrush.java
+++ b/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/util/WorldEditBrush.java
@@ -168,7 +168,7 @@ public final class WorldEditBrush {
      * @return true if the item stack is not of type block
      */
     public static boolean canBeBound(ItemStack stack) {
-        return toItemType(stack).hasBlockType();
+        return !toItemType(stack).hasBlockType();
     }
 
     public static ItemType toItemType(ItemStack stack) {

--- a/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/util/WorldEditBrush.java
+++ b/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/util/WorldEditBrush.java
@@ -13,11 +13,13 @@ import com.sk89q.worldedit.command.tool.BrushTool;
 import com.sk89q.worldedit.command.tool.InvalidToolBindException;
 import com.sk89q.worldedit.command.tool.brush.Brush;
 import com.sk89q.worldedit.extension.platform.Actor;
+import com.sk89q.worldedit.world.item.ItemType;
 import de.eldoria.eldoutilities.messages.MessageSender;
 import de.eldoria.schematicbrush.SchematicBrushReborn;
 import de.eldoria.schematicbrush.brush.SchematicBrush;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
@@ -111,20 +113,66 @@ public final class WorldEditBrush {
      * @return true if the brush was set.
      */
     public static boolean setBrush(Player player, Brush brush, String permission) {
-        var itemInMainHand = player.getInventory().getItemInMainHand();
+        var stack = player.getInventory().getItemInMainHand();
         try {
             var brushTool = new BrushTool(permission);
             brushTool.setBrush(brush, permission);
             if (FAWE.isFawe()) {
-                getLocalSession(player).setTool(BukkitAdapter.asItemType(itemInMainHand.getType()).getDefaultState(), brushTool, BukkitAdapter.adapt(player));
+                getLocalSession(player).setTool(toItemType(stack).getDefaultState(), brushTool, BukkitAdapter.adapt(player));
             } else {
-                getLocalSession(player).setTool(BukkitAdapter.asItemType(itemInMainHand.getType()), brushTool);
+                getLocalSession(player).setTool(toItemType(stack), brushTool);
             }
         } catch (InvalidToolBindException e) {
             MessageSender.getPluginMessageSender(SchematicBrushReborn.class).sendError(player, e.getMessage());
             return false;
         }
         return true;
+    }
+
+    /**
+     * Remove the brush for a player of the item in its main hand.
+     *
+     * @param player player to set
+     * @return true if the brush was remove.
+     */
+    public static boolean removeBrush(Player player) {
+        var stack = player.getInventory().getItemInMainHand();
+        return removeBrush(player, stack);
+    }
+
+    /**
+     * Remove a brush for this player on the item stack type..
+     *
+     * @param player player to set
+     * @param stack  the item stack
+     * @return true if the brush was removed.
+     */
+    public static boolean removeBrush(Player player, ItemStack stack) {
+        try {
+            if (FAWE.isFawe()) {
+                getLocalSession(player).setTool(toItemType(stack).getDefaultState(), null, BukkitAdapter.adapt(player));
+            } else {
+                getLocalSession(player).setTool(toItemType(stack), null);
+            }
+        } catch (InvalidToolBindException e) {
+            MessageSender.getPluginMessageSender(SchematicBrushReborn.class).sendError(player, e.getMessage());
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Checks if the stack is not of type block.
+     *
+     * @param stack stack
+     * @return true if the item stack is not of type block
+     */
+    public static boolean canBeBound(ItemStack stack) {
+        return toItemType(stack).hasBlockType();
+    }
+
+    public static ItemType toItemType(ItemStack stack) {
+        return BukkitAdapter.asItemType(stack.getType());
     }
 
     /**

--- a/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/util/WorldEditBrush.java
+++ b/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/util/WorldEditBrush.java
@@ -100,10 +100,21 @@ public final class WorldEditBrush {
      * @return true if the brush was set.
      */
     public static boolean setBrush(Player player, Brush brush) {
+        return setBrush(player, brush, "schematicbrush.brush.use");
+    }
+
+    /**
+     * Set the brush for a player and the item in its main hand.
+     *
+     * @param player player to set
+     * @param brush  brush to set
+     * @return true if the brush was set.
+     */
+    public static boolean setBrush(Player player, Brush brush, String permission) {
         var itemInMainHand = player.getInventory().getItemInMainHand();
         try {
-            var brushTool = new BrushTool("schematicbrush.brush.use");
-            brushTool.setBrush(brush, "schematicbrush.brush.use");
+            var brushTool = new BrushTool(permission);
+            brushTool.setBrush(brush, permission);
             if (FAWE.isFawe()) {
                 getLocalSession(player).setTool(BukkitAdapter.asItemType(itemInMainHand.getType()).getDefaultState(), brushTool, BukkitAdapter.adapt(player));
             } else {

--- a/schematicbrushreborn-core/build.gradle.kts
+++ b/schematicbrushreborn-core/build.gradle.kts
@@ -60,8 +60,8 @@ tasks {
         relocate("de.eldoria.messageblocker", shadebase + "messageblocker")
         relocate("net.kyori", shadebase + "kyori")
         mergeServiceFiles()
-        minimize()
         archiveClassifier.set("")
+        archiveVersion.set(rootProject.version as String)
         archiveBaseName.set("SchematicBrushReborn")
     }
 

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/SchematicBrushRebornImpl.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/SchematicBrushRebornImpl.java
@@ -169,6 +169,13 @@ public class SchematicBrushRebornImpl extends SchematicBrushReborn {
         metrics.addCustomChart(new AdvancedPie("installed_storage_type",
                 () -> storageRegistry.registry().keySet().stream().collect(Collectors.toMap(Nameable::name, e -> 1))));
 
+        metrics.addCustomChart(new AdvancedPie("installed_add_ons",
+                () -> Arrays.stream(getServer().getPluginManager().getPlugins())
+                        .filter(plugin -> {
+                            var descr = plugin.getDescription();
+                            return descr.getSoftDepend().contains("SchematicBrushReborn") || descr.getDepend().contains("SchematicBrushReborn");
+                        }).collect(Collectors.toMap(e -> e.getDescription().getName(), e -> 1))));
+
         metrics.addCustomChart(new SimplePie("used_storage_type",
                 () -> configuration.general().storageType().name()));
 

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/BrushPasteImpl.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/BrushPasteImpl.java
@@ -20,9 +20,14 @@ import de.eldoria.schematicbrush.brush.config.SchematicSet;
 import de.eldoria.schematicbrush.brush.config.modifier.PlacementModifier;
 import de.eldoria.schematicbrush.brush.config.modifier.SchematicModifier;
 import de.eldoria.schematicbrush.brush.config.provider.Mutator;
+import de.eldoria.schematicbrush.brush.config.util.Shiftable;
 import de.eldoria.schematicbrush.schematics.Schematic;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 import java.util.logging.Level;
 
 /**
@@ -52,23 +57,27 @@ public class BrushPasteImpl implements BrushPaste {
     @Override
     public boolean shiftFlip() {
         reloadSchematic();
-        schematicSet.getMutator(SchematicModifier.FLIP).shift();
-        return schematicSet.getMutator(SchematicModifier.FLIP).shiftable();
+        return shift(schematicSet.getMutator(SchematicModifier.FLIP), settings.getMutator(PlacementModifier.FLIP));
     }
 
     @Override
     public boolean shiftRotation() {
         reloadSchematic();
-        schematicSet.getMutator(SchematicModifier.ROTATION).shift();
-        return schematicSet.getMutator(SchematicModifier.ROTATION).shiftable();
+        return shift(schematicSet.getMutator(SchematicModifier.ROTATION), settings.getMutator(PlacementModifier.ROTATION));
     }
 
     @Override
     public boolean shiftOffset() {
         reloadSchematic();
-        schematicSet.getMutator(SchematicModifier.OFFSET).shift();
-        settings.getMutator(PlacementModifier.OFFSET).shift();
-        return settings.getMutator(PlacementModifier.OFFSET).shiftable() || schematicSet.getMutator(SchematicModifier.OFFSET).shiftable();
+        return shift(schematicSet.getMutator(SchematicModifier.OFFSET), settings.getMutator(PlacementModifier.OFFSET));
+    }
+
+    private boolean shift(Mutator<?>... mutators) {
+        var shifts = new ArrayList<>(Arrays.asList(mutators));
+        shifts.removeIf(Objects::isNull);
+        if (shifts.isEmpty()) return false;
+        shifts.forEach(Mutator::shift);
+        return shifts.stream().anyMatch(Shiftable::shiftable);
     }
 
     @Override

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/config/sections/brushes/YamlBrushContainer.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/config/sections/brushes/YamlBrushContainer.java
@@ -9,6 +9,7 @@ package de.eldoria.schematicbrush.config.sections.brushes;
 import de.eldoria.eldoutilities.serialization.SerializationUtil;
 import de.eldoria.schematicbrush.storage.ContainerPagedAccess;
 import de.eldoria.schematicbrush.storage.YamlContainerPagedAccess;
+import de.eldoria.schematicbrush.storage.base.Container;
 import de.eldoria.schematicbrush.storage.brush.Brush;
 import de.eldoria.schematicbrush.storage.brush.BrushContainer;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
@@ -29,12 +30,12 @@ import java.util.concurrent.CompletableFuture;
 
 @SerializableAs("sbrYamlBrushContainer")
 public class YamlBrushContainer implements BrushContainer, ConfigurationSerializable {
-    private final UUID uuid;
+    private UUID uuid;
     private final Map<String, Brush> brushes;
 
     public YamlBrushContainer(Map<String, Object> objectMap) {
         var map = SerializationUtil.mapOf(objectMap);
-        uuid = UUID.fromString(map.getValue("uuid"));
+        uuid = UUID.fromString(map.getValueOrDefault("uuid", Container.GLOBAL.toString()));
         List<Brush> brushList = map.getValueOrDefault("brushes", Collections.emptyList());
         brushes = new HashMap<>();
         brushList.forEach(p -> brushes.put(p.name(), p));
@@ -97,5 +98,10 @@ public class YamlBrushContainer implements BrushContainer, ConfigurationSerializ
     @Override
     public @NotNull UUID owner() {
         return uuid;
+    }
+
+    public YamlBrushContainer updateOwner(UUID uuid) {
+        this.uuid = uuid;
+        return this;
     }
 }

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/config/sections/brushes/YamlBrushContainer.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/config/sections/brushes/YamlBrushContainer.java
@@ -24,19 +24,25 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 @SerializableAs("sbrYamlBrushContainer")
 public class YamlBrushContainer implements BrushContainer, ConfigurationSerializable {
-    private final Map<String, Brush> brushes = new HashMap<>();
+    private final UUID uuid;
+    private final Map<String, Brush> brushes;
 
     public YamlBrushContainer(Map<String, Object> objectMap) {
         var map = SerializationUtil.mapOf(objectMap);
+        uuid = UUID.fromString(map.getValue("uuid"));
         List<Brush> brushList = map.getValueOrDefault("brushes", Collections.emptyList());
+        brushes = new HashMap<>();
         brushList.forEach(p -> brushes.put(p.name(), p));
     }
 
-    public YamlBrushContainer() {
+    public YamlBrushContainer(UUID uuid) {
+        brushes = new HashMap<>();
+        this.uuid = uuid;
     }
 
     @Override
@@ -86,5 +92,10 @@ public class YamlBrushContainer implements BrushContainer, ConfigurationSerializ
     @Override
     public CompletableFuture<Integer> size() {
         return CompletableFuture.completedFuture(brushes.size());
+    }
+
+    @Override
+    public @NotNull UUID owner() {
+        return uuid;
     }
 }

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/config/sections/brushes/YamlBrushes.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/config/sections/brushes/YamlBrushes.java
@@ -7,6 +7,7 @@
 package de.eldoria.schematicbrush.config.sections.brushes;
 
 import de.eldoria.eldoutilities.serialization.SerializationUtil;
+import de.eldoria.schematicbrush.storage.base.Container;
 import de.eldoria.schematicbrush.storage.brush.BrushContainer;
 import de.eldoria.schematicbrush.storage.brush.Brushes;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
@@ -27,12 +28,12 @@ public class YamlBrushes implements Brushes, ConfigurationSerializable {
     public YamlBrushes(Map<String, Object> objectMap) {
         var map = SerializationUtil.mapOf(objectMap);
         playerBrushes = map.getMap("playerBrushes", (key, v) -> UUID.fromString(key));
-        globalBrushes = map.getValueOrDefault("globalBrushes", new YamlBrushContainer());
+        globalBrushes = map.getValueOrDefault("globalBrushes", new YamlBrushContainer(Container.GLOBAL));
     }
 
     public YamlBrushes() {
         playerBrushes = new HashMap<>();
-        globalBrushes = new YamlBrushContainer();
+        globalBrushes = new YamlBrushContainer(Container.GLOBAL);
     }
 
     @Override
@@ -51,7 +52,7 @@ public class YamlBrushes implements Brushes, ConfigurationSerializable {
 
     @Override
     public BrushContainer playerContainer(UUID player) {
-        return playerBrushes.computeIfAbsent(player, key -> new YamlBrushContainer());
+        return playerBrushes.computeIfAbsent(player, key -> new YamlBrushContainer(player));
     }
 
     @Override

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/config/sections/brushes/YamlBrushes.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/config/sections/brushes/YamlBrushes.java
@@ -52,7 +52,7 @@ public class YamlBrushes implements Brushes, ConfigurationSerializable {
 
     @Override
     public BrushContainer playerContainer(UUID player) {
-        return playerBrushes.computeIfAbsent(player, key -> new YamlBrushContainer(player));
+        return playerBrushes.computeIfAbsent(player, key -> new YamlBrushContainer(player)).updateOwner(player);
     }
 
     @Override

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/config/sections/presets/YamlPresetContainer.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/config/sections/presets/YamlPresetContainer.java
@@ -9,6 +9,7 @@ package de.eldoria.schematicbrush.config.sections.presets;
 import de.eldoria.eldoutilities.serialization.SerializationUtil;
 import de.eldoria.schematicbrush.storage.ContainerPagedAccess;
 import de.eldoria.schematicbrush.storage.YamlContainerPagedAccess;
+import de.eldoria.schematicbrush.storage.base.Container;
 import de.eldoria.schematicbrush.storage.preset.Preset;
 import de.eldoria.schematicbrush.storage.preset.PresetContainer;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
@@ -29,12 +30,12 @@ import java.util.concurrent.CompletableFuture;
 
 @SerializableAs("sbrYamlPresetContainer")
 public class YamlPresetContainer implements PresetContainer, ConfigurationSerializable {
-    private final UUID uuid;
+    private UUID uuid;
     private final Map<String, Preset> presets;
 
     public YamlPresetContainer(Map<String, Object> objectMap) {
         var map = SerializationUtil.mapOf(objectMap);
-        uuid = UUID.fromString(map.getValue("uuid"));
+        uuid = UUID.fromString(map.getValueOrDefault("uuid", Container.GLOBAL.toString()));
         List<Preset> presetList = map.getValueOrDefault("presets", Collections.emptyList());
         presets = new HashMap<>();
         presetList.forEach(p -> presets.put(p.name(), p));
@@ -92,6 +93,11 @@ public class YamlPresetContainer implements PresetContainer, ConfigurationSerial
 
     @Override
     public @NotNull UUID owner() {
-        return null;
+        return uuid;
+    }
+
+    public YamlPresetContainer updateOwner(UUID uuid) {
+        this.uuid = uuid;
+        return this;
     }
 }

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/config/sections/presets/YamlPresetContainer.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/config/sections/presets/YamlPresetContainer.java
@@ -24,20 +24,24 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 @SerializableAs("sbrYamlPresetContainer")
 public class YamlPresetContainer implements PresetContainer, ConfigurationSerializable {
+    private final UUID uuid;
     private final Map<String, Preset> presets;
 
     public YamlPresetContainer(Map<String, Object> objectMap) {
         var map = SerializationUtil.mapOf(objectMap);
+        uuid = UUID.fromString(map.getValue("uuid"));
         List<Preset> presetList = map.getValueOrDefault("presets", Collections.emptyList());
         presets = new HashMap<>();
         presetList.forEach(p -> presets.put(p.name(), p));
     }
 
-    public YamlPresetContainer() {
+    public YamlPresetContainer(UUID uuid) {
+        this.uuid = uuid;
         presets = new HashMap<>();
     }
 
@@ -46,6 +50,7 @@ public class YamlPresetContainer implements PresetContainer, ConfigurationSerial
     public Map<String, Object> serialize() {
         return SerializationUtil.newBuilder()
                 .add("presets", new ArrayList<>(presets.values()))
+                .add("uuid", uuid.toString())
                 .build();
     }
 
@@ -83,5 +88,10 @@ public class YamlPresetContainer implements PresetContainer, ConfigurationSerial
     @Override
     public CompletableFuture<Integer> size() {
         return CompletableFuture.completedFuture(presets.size());
+    }
+
+    @Override
+    public @NotNull UUID owner() {
+        return null;
     }
 }

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/config/sections/presets/YamlPresets.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/config/sections/presets/YamlPresets.java
@@ -52,7 +52,7 @@ public class YamlPresets implements Presets, ConfigurationSerializable {
 
     @Override
     public PresetContainer playerContainer(UUID player) {
-        return playerPresets.computeIfAbsent(player, key -> new YamlPresetContainer(player));
+        return playerPresets.computeIfAbsent(player, key -> new YamlPresetContainer(player)).updateOwner(player);
     }
 
     @Override

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/config/sections/presets/YamlPresets.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/config/sections/presets/YamlPresets.java
@@ -7,6 +7,7 @@
 package de.eldoria.schematicbrush.config.sections.presets;
 
 import de.eldoria.eldoutilities.serialization.SerializationUtil;
+import de.eldoria.schematicbrush.storage.base.Container;
 import de.eldoria.schematicbrush.storage.preset.PresetContainer;
 import de.eldoria.schematicbrush.storage.preset.Presets;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
@@ -27,12 +28,12 @@ public class YamlPresets implements Presets, ConfigurationSerializable {
     public YamlPresets(Map<String, Object> objectMap) {
         var map = SerializationUtil.mapOf(objectMap);
         playerPresets = map.getMap("playerPresets", (key, v) -> UUID.fromString(key));
-        globalPresets = map.getValueOrDefault("globalPresets", new YamlPresetContainer());
+        globalPresets = map.getValueOrDefault("globalPresets", new YamlPresetContainer(Container.GLOBAL));
     }
 
     public YamlPresets() {
         playerPresets = new HashMap<>();
-        globalPresets = new YamlPresetContainer();
+        globalPresets = new YamlPresetContainer(Container.GLOBAL);
     }
 
     @Override
@@ -51,7 +52,7 @@ public class YamlPresets implements Presets, ConfigurationSerializable {
 
     @Override
     public PresetContainer playerContainer(UUID player) {
-        return playerPresets.computeIfAbsent(player, key -> new YamlPresetContainer());
+        return playerPresets.computeIfAbsent(player, key -> new YamlPresetContainer(player));
     }
 
     @Override

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/schematics/SchematicWatchService.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/schematics/SchematicWatchService.java
@@ -138,7 +138,12 @@ public class SchematicWatchService implements Runnable {
         }
 
         for (var source : sources) {
-            var path = Paths.get(root, source.path());
+            Path path;
+            if (source.isRelative()) {
+                path = Paths.get(root, source.path());
+            } else {
+                path = Paths.get(source.path());
+            }
             watchDirectory(watchService, path);
         }
     }


### PR DESCRIPTION
Fixes:
- Watch service for new schematic detection not registered on sources with absolute path
- Shifting flip, rotation or offset didnt worked when not set on brush and schematic set.

Api Changes:
- Container now require awareness about the owners UUID. Global containers should use the UUID provided by Container.GLOBAL