### PR TITLE
Prevent binding a brush to a block

### DIFF
--- a/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/util/WorldEditBrush.java
+++ b/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/util/WorldEditBrush.java
@@ -118,7 +118,7 @@ public final class WorldEditBrush {
             var brushTool = new BrushTool(permission);
             brushTool.setBrush(brush, permission);
             if (toItemType(stack).hasBlockType()) {
-                MessageSender.getPluginMessageSender(SchematicBrushReborn.class).sendError(player, "Can not bind brush on a blick.");
+                MessageSender.getPluginMessageSender(SchematicBrushReborn.class).sendError(player, "Can not bind brush on a block.");
                 return false;
             }
             if (FAWE.isFawe()) {

--- a/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/util/WorldEditBrush.java
+++ b/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/util/WorldEditBrush.java
@@ -117,6 +117,10 @@ public final class WorldEditBrush {
         try {
             var brushTool = new BrushTool(permission);
             brushTool.setBrush(brush, permission);
+            if (toItemType(stack).hasBlockType()) {
+                MessageSender.getPluginMessageSender(SchematicBrushReborn.class).sendError(player, "Can not bind brush on a blick.");
+                return false;
+            }
             if (FAWE.isFawe()) {
                 getLocalSession(player).setTool(toItemType(stack).getDefaultState(), brushTool, BukkitAdapter.adapt(player));
             } else {


### PR DESCRIPTION
Fawe seems to be stupid again and only blocks brinding on a brush of type air, while world edit blocks binding a brush to a block in general.

This patch fixes the fawe behavior, by checking for a block in general.