### PR TITLE
Release 2.2.5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "de.eldoria"
-version = "2.2.4"
+version = "2.2.5"
 
 subprojects {
     apply {

--- a/buildSrc/src/main/kotlin/de.eldoria.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/de.eldoria.java-conventions.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
 
     testImplementation(platform("org.junit:junit-bom:5.9.0"))
     testImplementation("org.junit.jupiter", "junit-jupiter")
-    testImplementation("com.github.seeseemelk", "MockBukkit-v1.19", "2.111.6")
+    testImplementation("com.github.seeseemelk", "MockBukkit-v1.19", "2.117.0")
     testImplementation("com.sk89q.worldedit", "worldedit-bukkit", "7.2.12")
     testImplementation("com.fastasyncworldedit:FastAsyncWorldEdit-Core:2.4.3"){
         exclude("com.intellectualsites.paster")

--- a/buildSrc/src/main/kotlin/de.eldoria.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/de.eldoria.java-conventions.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
 
     testImplementation(platform("org.junit:junit-bom:5.9.0"))
     testImplementation("org.junit.jupiter", "junit-jupiter")
-    testImplementation("com.github.seeseemelk", "MockBukkit-v1.19", "2.117.0")
+    testImplementation("com.github.seeseemelk", "MockBukkit-v1.19", "2.117.1")
     testImplementation("com.sk89q.worldedit", "worldedit-bukkit", "7.2.12")
     testImplementation("com.fastasyncworldedit:FastAsyncWorldEdit-Core:2.4.3"){
         exclude("com.intellectualsites.paster")

--- a/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/storage/brush/Brush.java
+++ b/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/storage/brush/Brush.java
@@ -158,7 +158,7 @@ public class Brush implements ConfigurationSerializable, Comparable<Brush> {
                 .space()
                 .text("<%s><click:run_command:'/sbrbp info %s'>[Info]</click>", Colors.ADD, (global ? "g:" : "") + name())
                 .space()
-                .text("<%s><click:run_command:'/sbr loadbrush %s'>[Load]</click>", Colors.ADD, name(), (global ? "g:" : "") + name());
+                .text("<%s><click:run_command:'/sbr loadbrush %s'>[Load]</click>", Colors.ADD, (global ? "g:" : "") + name());
         if (canDelete) {
             text.space().text("<%s><click:run_command:'/sbrbp remove %s %s'>[Remove]</click>", Colors.REMOVE, name(), global ? "-g" : "");
         }

--- a/schematicbrushreborn-core/build.gradle.kts
+++ b/schematicbrushreborn-core/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
 
     testImplementation(project(":schematicbrushreborn-api"))
     testImplementation("org.jetbrains", "annotations", "23.0.0")
-    testImplementation("org.mockito", "mockito-core", "4.5.1")
+    testImplementation("org.mockito", "mockito-core", "4.7.0")
     testImplementation("com.fasterxml.jackson.core", "jackson-databind", "2.13.3")
 }
 

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/commands/brush/RemoveSet.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/commands/brush/RemoveSet.java
@@ -39,7 +39,7 @@ public class RemoveSet extends AdvancedCommand implements IPlayerTabExecutor {
         if (!success) {
             messageSender().send(MessageChannel.ACTION_BAR, MessageType.ERROR, player, "Invalid set.");
         }
-        sessions.showBrush(player);
+        sessions.showSets(player);
     }
 
     @Override

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/commands/preset/Info.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/commands/preset/Info.java
@@ -58,7 +58,7 @@ public class Info extends AdvancedCommand implements IPlayerTabExecutor {
                     var composer = MessageComposer.create()
                             .text(preset.detailComponent(global))
                             .newLine()
-                            .text("<click:run_command:'/sbrbp list %s'><%s>[Back]</click>", Colors.CHANGE, global ? "global" : "private")
+                            .text("<click:run_command:'/sbrp list %s'><%s>[Back]</click>", global ? "global" : "private", Colors.CHANGE)
                             .prependLines(20);
                     messageBlocker.ifEnabled(composer, comp -> comp.newLine().text("<click:run_command:'/sbrs chatblock false'><%s>[x]</click>", Colors.REMOVE));
                     messageBlocker.announce(player, "[x]");

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/config/sections/brushes/YamlBrushContainer.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/config/sections/brushes/YamlBrushContainer.java
@@ -38,7 +38,7 @@ public class YamlBrushContainer implements BrushContainer, ConfigurationSerializ
         uuid = UUID.fromString(map.getValueOrDefault("uuid", Container.GLOBAL.toString()));
         List<Brush> brushList = map.getValueOrDefault("brushes", Collections.emptyList());
         brushes = new HashMap<>();
-        brushList.forEach(p -> brushes.put(p.name(), p));
+        brushList.forEach(p -> brushes.put(p.name().toLowerCase(Locale.ROOT), p));
     }
 
     public YamlBrushContainer(UUID uuid) {

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/config/sections/presets/YamlPresetContainer.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/config/sections/presets/YamlPresetContainer.java
@@ -38,7 +38,7 @@ public class YamlPresetContainer implements PresetContainer, ConfigurationSerial
         uuid = UUID.fromString(map.getValueOrDefault("uuid", Container.GLOBAL.toString()));
         List<Preset> presetList = map.getValueOrDefault("presets", Collections.emptyList());
         presets = new HashMap<>();
-        presetList.forEach(p -> presets.put(p.name(), p));
+        presetList.forEach(p -> presets.put(p.name().toLowerCase(Locale.ROOT), p));
     }
 
     public YamlPresetContainer(UUID uuid) {

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/rendering/RenderService.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/rendering/RenderService.java
@@ -205,13 +205,19 @@ public class RenderService implements Runnable, Listener {
 
         @Override
         public void run() {
-            if (active) return;
-            active = true;
+            if(!claim()) return;
             while (!queue.isEmpty()) {
                 var poll = queue.poll();
                 poll.sendChanges();
             }
             active = false;
+        }
+
+        // There is a minimal chance of a race condition. That's why this method needs to be synchronized
+        private synchronized boolean claim() {
+            if (active) return false;
+            active = true;
+            return true;
         }
 
         public void queue(Player player, Changes oldChanges, Changes newChanges) {


### PR DESCRIPTION
A lot of bugfixes.

Thanks to all the people reporting those and making me aware of those issues. This really helps a lot!

- Fix a formatting issue in the brush info
- Fix wrong command when clicking on the back button in the preset info
- Fix back button going back to brush presets instead of presets in the brush preset info
- Fix race condition in the rendering mechanic causing it to stop working in rare cases
- Fix exception on startup when a number in a schematic name is larger than the max integer value
- Fix removing a set going back to overview instead of the set list
- Fix presets and brush names not recognized with yaml storage when using upper case names
