### PR TITLE
Implement brush history and schematic selection modes

### DIFF
--- a/schematicbrushreborn-api/build.gradle.kts
+++ b/schematicbrushreborn-api/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    api("de.eldoria", "eldo-util", "1.14.1")
+    api("de.eldoria", "eldo-util", "1.14.1-SNAPSHOT")
     api("de.eldoria", "messageblocker", "1.1.1")
     api("net.kyori", "adventure-platform-bukkit", "4.2.0")
     api("net.kyori", "adventure-text-minimessage", "4.12.0")

--- a/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/brush/BrushPaste.java
+++ b/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/brush/BrushPaste.java
@@ -101,7 +101,14 @@ public interface BrushPaste {
      *
      * @return true if the schematic changed
      */
-    boolean shiftSchematic();
+    boolean nextSchematic();
+
+    /**
+     * Shift to the previous schematic
+     *
+     * @return true if the schematic was changed
+     */
+    boolean previousSchematic();
 
     /**
      * Load a new clipboard from schematic file
@@ -143,4 +150,11 @@ public interface BrushPaste {
      * @return true if the offset was shiftable
      */
     boolean shiftOffset();
+
+    /**
+     * Get the brush which will paste this paste.
+     *
+     * @return schematic brush
+     */
+    SchematicBrush brush();
 }

--- a/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/brush/SchematicBrush.java
+++ b/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/brush/SchematicBrush.java
@@ -16,6 +16,7 @@ import com.sk89q.worldedit.util.Location;
 import de.eldoria.schematicbrush.brush.config.BrushSettings;
 import de.eldoria.schematicbrush.brush.config.BrushSettingsRegistry;
 import de.eldoria.schematicbrush.brush.config.builder.BrushBuilder;
+import de.eldoria.schematicbrush.brush.history.BrushHistory;
 import de.eldoria.schematicbrush.rendering.BlockChangeCollector;
 import de.eldoria.schematicbrush.schematics.SchematicRegistry;
 import org.bukkit.entity.Player;
@@ -62,7 +63,7 @@ public interface SchematicBrush extends Brush {
      *
      * @return settings
      */
-    BrushSettings getSettings();
+    BrushSettings settings();
 
     /**
      * Get the next paste which will be executed
@@ -79,4 +80,6 @@ public interface SchematicBrush extends Brush {
      * @return brush as builder
      */
     BrushBuilder toBuilder(BrushSettingsRegistry settingsRegistry, SchematicRegistry schematicRegistry);
+
+    BrushHistory history();
 }

--- a/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/brush/config/BrushSettings.java
+++ b/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/brush/config/BrushSettings.java
@@ -6,26 +6,31 @@
 
 package de.eldoria.schematicbrush.brush.config;
 
+import de.eldoria.eldoutilities.container.Pair;
 import de.eldoria.schematicbrush.brush.PasteMutation;
+import de.eldoria.schematicbrush.brush.SchematicBrush;
 import de.eldoria.schematicbrush.brush.config.builder.BrushBuilder;
 import de.eldoria.schematicbrush.brush.config.modifier.PlacementModifier;
 import de.eldoria.schematicbrush.brush.config.provider.Mutator;
+import de.eldoria.schematicbrush.brush.config.schematics.SchematicSelection;
 import de.eldoria.schematicbrush.brush.config.util.Randomable;
+import de.eldoria.schematicbrush.schematics.Schematic;
 import de.eldoria.schematicbrush.schematics.SchematicRegistry;
 import org.bukkit.entity.Player;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Setting of a {@link de.eldoria.schematicbrush.brush.SchematicBrush}
  */
 public interface BrushSettings extends Randomable {
     /**
-     * Get a random schematic set from the {@link #schematicSets} list based on their {@link SchematicSet#weight()}.
+     * Get the next schematic and the set containing it from the {@link #schematicSets} list based on their {@link SchematicSet#weight()}.
      *
      * @return a random brush
      */
-    SchematicSet getRandomSchematicSet();
+    Optional<Pair<SchematicSet, Schematic>> nextSchematic(SchematicBrush brush);
 
     /**
      * Counts all schematics in all brushes. No deduplication.
@@ -77,4 +82,12 @@ public interface BrushSettings extends Randomable {
      * Refresehs the underlying mutators.
      */
     void refreshMutator();
+
+    /**
+     * Get the current schematic selection mode
+     * @return schematic selection mode
+     */
+    SchematicSelection schematicSelection();
+
+    void schematicSelection(SchematicSelection schematicSelection);
 }

--- a/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/brush/config/BrushSettingsRegistry.java
+++ b/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/brush/config/BrushSettingsRegistry.java
@@ -13,7 +13,9 @@ import de.eldoria.schematicbrush.brush.config.modifier.PlacementModifier;
 import de.eldoria.schematicbrush.brush.config.modifier.SchematicModifier;
 import de.eldoria.schematicbrush.brush.config.provider.ModifierProvider;
 import de.eldoria.schematicbrush.brush.config.provider.Mutator;
+import de.eldoria.schematicbrush.brush.config.provider.SchematicSelectionProvider;
 import de.eldoria.schematicbrush.brush.config.provider.SelectorProvider;
+import de.eldoria.schematicbrush.brush.config.schematics.SchematicSelection;
 import de.eldoria.schematicbrush.brush.config.selector.Selector;
 import de.eldoria.schematicbrush.brush.config.util.Nameable;
 import de.eldoria.schematicbrush.brush.exceptions.AlreadyRegisteredException;
@@ -37,6 +39,15 @@ public interface BrushSettingsRegistry {
      * @throws AlreadyRegisteredException when a selector with this name is already registered
      */
     void registerSelector(SelectorProvider provider);
+    /**
+     * Registers a new schematic selection.
+     * <p>
+     * This will also call {@link ConfigurationSerialization#registerClass(Class)}
+     *
+     * @param provider provider of the schematic selection
+     * @throws AlreadyRegisteredException when a schematic selection with this name is already registered
+     */
+    void registerSchematicSelection(SchematicSelectionProvider provider);
 
     /**
      * Register a new schematic modifier.
@@ -91,6 +102,15 @@ public interface BrushSettingsRegistry {
     Selector parseSelector(Arguments args) throws CommandException;
 
     /**
+     * Parse a schematic selection from arguments
+     *
+     * @param args arguments to parse
+     * @return the parsed selector
+     * @throws CommandException if the arguments could not be parsed
+     */
+    SchematicSelection parseSchematicSelection(Arguments args) throws CommandException;
+
+    /**
      * Parse a schematic modifier from arguments
      *
      * @param args arguments to parse
@@ -114,6 +134,13 @@ public interface BrushSettingsRegistry {
      * @return unmodifiable list of selectors
      */
     List<SelectorProvider> selector();
+
+    /**
+     * Get registered schematic selections.
+     *
+     * @return unmodifiable list of selectors
+     */
+    List<SchematicSelectionProvider> schematicSelections();
 
     /**
      * Get registered schematic modifier
@@ -154,6 +181,16 @@ public interface BrushSettingsRegistry {
      * @throws CommandException if the arguments are invalid
      */
     List<String> completeSelector(Arguments args, Player player) throws CommandException;
+
+    /**
+     * Complete schematic selection
+     *
+     * @param args   arguments to complete
+     * @param player player which requested completion
+     * @return list of possible values
+     * @throws CommandException if the arguments are invalid
+     */
+    List<String> completeSchematicSelection(Arguments args, Player player) throws CommandException;
 
     /**
      * Complete placement modifier

--- a/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/brush/config/SchematicSet.java
+++ b/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/brush/config/SchematicSet.java
@@ -30,14 +30,6 @@ public interface SchematicSet extends Randomable {
     Mutator<?> getMutator(SchematicModifier type);
 
     /**
-     * Get a random schematic from the set
-     *
-     * @return schematic
-     */
-    @Nullable
-    Schematic getRandomSchematic();
-
-    /**
      * Update a not weighted brush.
      *
      * @param weight weight to set.

--- a/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/brush/config/provider/SchematicSelectionProvider.java
+++ b/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/brush/config/provider/SchematicSelectionProvider.java
@@ -1,0 +1,22 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2021 EldoriaRPG Team and Contributor
+ */
+
+package de.eldoria.schematicbrush.brush.config.provider;
+
+import de.eldoria.schematicbrush.brush.config.schematics.SchematicSelection;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+
+public abstract class SchematicSelectionProvider extends SettingProvider<SchematicSelection>{
+    /**
+     * Create a new settings provider
+     *
+     * @param clazz which is returned by the provider
+     * @param name  name. Must be unique inside the provider.
+     */
+    public SchematicSelectionProvider(Class<? extends ConfigurationSerializable> clazz, String name) {
+        super(clazz, name);
+    }
+}

--- a/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/brush/config/schematics/SchematicSelection.java
+++ b/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/brush/config/schematics/SchematicSelection.java
@@ -1,0 +1,20 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2021 EldoriaRPG Team and Contributor
+ */
+
+package de.eldoria.schematicbrush.brush.config.schematics;
+
+import de.eldoria.eldoutilities.container.Pair;
+import de.eldoria.schematicbrush.brush.SchematicBrush;
+import de.eldoria.schematicbrush.brush.config.SchematicSet;
+import de.eldoria.schematicbrush.brush.config.util.Randomable;
+import de.eldoria.schematicbrush.schematics.Schematic;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+
+import java.util.Optional;
+
+public interface SchematicSelection extends Randomable, ConfigurationSerializable {
+    Optional<Pair<SchematicSet, Schematic>> nextSchematic(SchematicBrush brush, boolean force);
+}

--- a/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/brush/history/BrushHistory.java
+++ b/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/brush/history/BrushHistory.java
@@ -1,0 +1,39 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2021 EldoriaRPG Team and Contributor
+ */
+
+package de.eldoria.schematicbrush.brush.history;
+
+import de.eldoria.eldoutilities.container.Pair;
+import de.eldoria.schematicbrush.brush.config.SchematicSet;
+import de.eldoria.schematicbrush.schematics.Schematic;
+
+import java.util.Optional;
+
+public interface BrushHistory {
+    /**
+     * Get and remove the head of the history.
+     *
+     * @return current head of the history if present
+     */
+    Optional<Pair<SchematicSet, Schematic>> previous();
+
+    /**
+     * Push a new entry into the registry. The element will become the new head of the history if it is not the head already.
+     *
+     * @param set       set
+     * @param schematic schematic
+     */
+    void push(SchematicSet set, Schematic schematic);
+
+    /**
+     * Push a new entry into the registry. The element will become the new head of the history if it is not the head already.
+     *
+     * @param pair set and schematic pair
+     */
+    default void push(Pair<SchematicSet, Schematic> pair) {
+        push(pair.first, pair.second);
+    }
+}

--- a/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/schematics/Schematic.java
+++ b/schematicbrushreborn-api/src/main/java/de/eldoria/schematicbrush/schematics/Schematic.java
@@ -296,4 +296,12 @@ public class Schematic implements Comparable<Schematic> {
         }
         return name;
     }
+
+    @Override
+    public String toString() {
+        return "Schematic{" +
+                "file=" + file +
+                ", name='" + name + '\'' +
+                '}';
+    }
 }

--- a/schematicbrushreborn-core/build.gradle.kts
+++ b/schematicbrushreborn-core/build.gradle.kts
@@ -119,6 +119,11 @@ bukkit {
             aliases = listOf("sbrbp", "schbrbp")
             permission = "schematicbrush.brushpreset.use"
         }
+        register("schematicbrushbrushmodify") {
+            description = "Edit settings of the current brush"
+            aliases = listOf("sbrm", "schbrm")
+            permission = "schematicbrush.brush.use"
+        }
     }
 
     permissions {

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/SchematicBrushRebornImpl.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/SchematicBrushRebornImpl.java
@@ -22,10 +22,7 @@ import de.eldoria.schematicbrush.brush.config.BrushSettingsRegistryImpl;
 import de.eldoria.schematicbrush.brush.config.builder.BrushBuilderSnapshotImpl;
 import de.eldoria.schematicbrush.brush.config.builder.SchematicSetBuilderImpl;
 import de.eldoria.schematicbrush.brush.config.util.Nameable;
-import de.eldoria.schematicbrush.commands.Admin;
-import de.eldoria.schematicbrush.commands.Brush;
-import de.eldoria.schematicbrush.commands.BrushPresets;
-import de.eldoria.schematicbrush.commands.Settings;
+import de.eldoria.schematicbrush.commands.*;
 import de.eldoria.schematicbrush.config.Configuration;
 import de.eldoria.schematicbrush.config.ConfigurationImpl;
 import de.eldoria.schematicbrush.config.sections.GeneralConfigImpl;
@@ -115,6 +112,7 @@ public class SchematicBrushRebornImpl extends SchematicBrushReborn {
         var adminCommand = new Admin(this, schematics, storageRegistry);
         var settingsCommand = new Settings(this, configuration, renderService, notifyListener, messageBlocker);
         var brushPresetsCommand = new BrushPresets(this, storage, messageBlocker, settingsRegistry);
+        var modifyCommand = new Modify(this, settingsRegistry);
 
         enableMetrics();
 
@@ -126,6 +124,7 @@ public class SchematicBrushRebornImpl extends SchematicBrushReborn {
         registerCommand(adminCommand);
         registerCommand(settingsCommand);
         registerCommand(brushPresetsCommand);
+        registerCommand(modifyCommand);
 
         if (configuration.general().isCheckUpdates() && UserData.get(this).isSpigotPremium()) {
             Updater.spigot(new SpigotUpdateData(this, Permissions.Admin.RELOAD, configuration.general()

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/BrushPasteImpl.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/BrushPasteImpl.java
@@ -161,12 +161,12 @@ public class BrushPasteImpl implements BrushPaste {
      */
     @Override
     public boolean nextSchematic() {
+        brush.history().push(schematicSet, schematic);
         var next = settings.nextSchematic(brush);
         if (schematicSet.schematics().isEmpty() || next.isEmpty()) return false;
         next.ifPresent(pair -> {
             schematicSet = pair.first;
             schematic = pair.second;
-            brush.history().push(pair);
         });
         reloadSchematic();
         return true;

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/BrushPasteImpl.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/BrushPasteImpl.java
@@ -33,12 +33,14 @@ import java.util.logging.Level;
  * Represents the next paste executed by the brush.
  */
 public class BrushPasteImpl implements BrushPaste {
+    private final SchematicBrush brush;
     private final BrushSettings settings;
     private SchematicSet schematicSet;
     private Schematic schematic;
     private Clipboard clipboard;
 
-    public BrushPasteImpl(BrushSettings settings, SchematicSet schematicSet, Schematic schematic) {
+    public BrushPasteImpl(SchematicBrush brush, BrushSettings settings, SchematicSet schematicSet, Schematic schematic) {
+        this.brush = brush;
         this.settings = settings;
         this.schematicSet = schematicSet;
         this.schematic = schematic;
@@ -140,10 +142,10 @@ public class BrushPasteImpl implements BrushPaste {
     private Operation paste(ClipboardHolder clipboardHolder, Extent targetExtent, BlockVector3 position, PasteMutation mutation) {
         // Create paste operation
         return clipboardHolder.createPaste(targetExtent)
-                              .to(position.add(mutation.pasteOffset()))
-                              .ignoreAirBlocks(!mutation.isIncludeAir())
-                              .maskSource(mutation.maskSource())
-                              .build();
+                .to(position.add(mutation.pasteOffset()))
+                .ignoreAirBlocks(!mutation.isIncludeAir())
+                .maskSource(mutation.maskSource())
+                .build();
     }
 
     private ClipboardHolder buildClipboard(PasteMutation mutation) {
@@ -158,24 +160,30 @@ public class BrushPasteImpl implements BrushPaste {
      * @return true if the schematic was changed
      */
     @Override
-    public boolean shiftSchematic() {
-        schematicSet = settings.getRandomSchematicSet();
-        if (schematicSet.schematics().isEmpty()) return false;
-        var newSchematic = schematicSet.getRandomSchematic();
-        while (newSchematic == schematic) {
-            newSchematic = schematicSet.getRandomSchematic();
-            if (schematicSet.schematics().isEmpty()) return false;
-            if (newSchematic == null) continue;
-            if (schematicSet.schematics().size() <= 1) break;
-        }
+    public boolean nextSchematic() {
+        var next = settings.nextSchematic(brush);
+        if (schematicSet.schematics().isEmpty() || next.isEmpty()) return false;
+        next.ifPresent(pair -> {
+            schematicSet = pair.first;
+            schematic = pair.second;
+            brush.history().push(pair);
+        });
+        reloadSchematic();
+        return true;
+    }
 
-        schematic = newSchematic;
+    @Override
+    public boolean previousSchematic() {
+        var next = brush.history().previous();
+        if (schematicSet.schematics().isEmpty() || next.isEmpty()) return false;
+        schematicSet = next.get().first;
+        schematic = next.get().second;
         reloadSchematic();
         return true;
     }
 
     /**
-     * Load a new clipboard from schematic file
+     * Load a new clipboard from schematic file\
      */
     @Override
     public final void reloadSchematic() {
@@ -227,7 +235,12 @@ public class BrushPasteImpl implements BrushPaste {
         var minimumPoint = clipboard.getMinimumPoint();
         var maximumPoint = clipboard.getMaximumPoint();
         return (long) EMath.diff(minimumPoint.getBlockX(), maximumPoint.getBlockX())
-               * EMath.diff(minimumPoint.getBlockY(), maximumPoint.getBlockY())
-               * EMath.diff(minimumPoint.getBlockZ(), maximumPoint.getBlockZ());
+                * EMath.diff(minimumPoint.getBlockY(), maximumPoint.getBlockY())
+                * EMath.diff(minimumPoint.getBlockZ(), maximumPoint.getBlockZ());
+    }
+
+    @Override
+    public SchematicBrush brush() {
+        return brush;
     }
 }

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/config/BrushSettingsImpl.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/config/BrushSettingsImpl.java
@@ -6,24 +6,30 @@
 
 package de.eldoria.schematicbrush.brush.config;
 
+import de.eldoria.eldoutilities.container.Pair;
 import de.eldoria.schematicbrush.brush.PasteMutation;
 import de.eldoria.schematicbrush.brush.PasteMutationImpl;
+import de.eldoria.schematicbrush.brush.SchematicBrush;
 import de.eldoria.schematicbrush.brush.config.builder.BrushBuilder;
 import de.eldoria.schematicbrush.brush.config.builder.BrushBuilderImpl;
 import de.eldoria.schematicbrush.brush.config.modifier.PlacementModifier;
 import de.eldoria.schematicbrush.brush.config.provider.Mutator;
+import de.eldoria.schematicbrush.brush.config.schematics.RandomSelection;
+import de.eldoria.schematicbrush.brush.config.schematics.SchematicSelection;
 import de.eldoria.schematicbrush.brush.config.util.Nameable;
 import de.eldoria.schematicbrush.brush.config.util.ValueProvider;
+import de.eldoria.schematicbrush.schematics.Schematic;
 import de.eldoria.schematicbrush.schematics.SchematicRegistry;
 import org.bukkit.entity.Player;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * A brush configuration represents the settings of a single brush. A brush consists of one or more brushes represented
  * by a {@link SchematicSetImpl} object. If more than one {@link SchematicSetImpl} is present, a random {@link SchematicSetImpl}
- * will be returned via the {@link #getRandomSchematicSet()} based on the {@link SchematicSetImpl#weight()} of the
+ * will be returned via the {@link #nextSchematic(SchematicBrush)}} based on the {@link SchematicSetImpl#weight()} of the
  * brushes. The brush settings contains some general brush settings, which apply to the whole brush and not only to
  * specific sub brushes.
  */
@@ -38,6 +44,7 @@ public final class BrushSettingsImpl implements BrushSettings {
      * The total weight of all brushes in the {@link #schematicSets} list
      */
     private int totalWeight;
+    private SchematicSelection schematicSelection = new RandomSelection();
 
     public BrushSettingsImpl(List<SchematicSet> schematicSets, Map<Nameable, Mutator<?>> placementModifier) {
         this.schematicSets = schematicSets;
@@ -69,23 +76,14 @@ public final class BrushSettingsImpl implements BrushSettings {
     }
 
     /**
-     * Get a random brush from the {@link #schematicSets} list based on their {@link SchematicSetImpl#weight()}.
+     * Get a random schematic from the {@link #schematicSets} list based on their {@link SchematicSetImpl#weight()}.
      *
      * @return a random brush
      */
     @Override
-    public SchematicSet getRandomSchematicSet() {
+    public Optional<Pair<SchematicSet, Schematic>> nextSchematic(SchematicBrush brush) {
         cleanUp();
-        var random = randomInt(totalWeight);
-
-        var count = 0;
-        for (var brush : schematicSets) {
-            if (count + brush.weight() > random) {
-                return brush;
-            }
-            count += brush.weight();
-        }
-        return schematicSets.get(schematicSets.size() - 1);
+        return schematicSelection.nextSchematic(brush, true);
     }
 
     /**
@@ -158,5 +156,15 @@ public final class BrushSettingsImpl implements BrushSettings {
     @Override
     public void refreshMutator() {
         placementModifier.values().forEach(ValueProvider::refresh);
+    }
+
+    @Override
+    public SchematicSelection schematicSelection() {
+        return schematicSelection;
+    }
+
+    @Override
+    public void schematicSelection(SchematicSelection schematicSelection) {
+        this.schematicSelection = schematicSelection;
     }
 }

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/config/BrushSettingsImpl.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/config/BrushSettingsImpl.java
@@ -44,9 +44,10 @@ public final class BrushSettingsImpl implements BrushSettings {
      * The total weight of all brushes in the {@link #schematicSets} list
      */
     private int totalWeight;
-    private SchematicSelection schematicSelection = new RandomSelection();
+    private  SchematicSelection schematicSelection;
 
-    public BrushSettingsImpl(List<SchematicSet> schematicSets, Map<Nameable, Mutator<?>> placementModifier) {
+    public BrushSettingsImpl(SchematicSelection schematicSelection, List<SchematicSet> schematicSets, Map<Nameable, Mutator<?>> placementModifier) {
+        this.schematicSelection = schematicSelection;
         this.schematicSets = schematicSets;
         this.placementModifier = placementModifier;
 
@@ -147,7 +148,7 @@ public final class BrushSettingsImpl implements BrushSettings {
      */
     @Override
     public BrushBuilder toBuilder(Player player, BrushSettingsRegistry settingsRegistry, SchematicRegistry schematicRegistry) {
-        var brushBuilder = new BrushBuilderImpl(player, settingsRegistry, schematicRegistry);
+        var brushBuilder = new BrushBuilderImpl(player, schematicSelection, settingsRegistry, schematicRegistry);
         placementModifier.forEach(brushBuilder::setPlacementModifier);
         schematicSets.stream().map(SchematicSet::toBuilder).forEach(brushBuilder::addSchematicSet);
         return brushBuilder;

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/config/SchematicSetImpl.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/config/SchematicSetImpl.java
@@ -6,8 +6,6 @@
 
 package de.eldoria.schematicbrush.brush.config;
 
-import com.sk89q.worldedit.extent.clipboard.Clipboard;
-import de.eldoria.schematicbrush.SchematicBrushReborn;
 import de.eldoria.schematicbrush.brush.PasteMutation;
 import de.eldoria.schematicbrush.brush.config.builder.SchematicSetBuilderImpl;
 import de.eldoria.schematicbrush.brush.config.modifier.SchematicModifier;
@@ -17,13 +15,7 @@ import de.eldoria.schematicbrush.brush.config.util.Nameable;
 import de.eldoria.schematicbrush.brush.config.util.ValueProvider;
 import de.eldoria.schematicbrush.schematics.Schematic;
 
-import javax.annotation.Nullable;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.logging.Level;
+import java.util.*;
 
 /**
  * The schematic set represents a part of a brush, which will be combined to a brush by the {@link BrushSettingsImpl} A
@@ -39,6 +31,7 @@ public class SchematicSetImpl implements SchematicSet {
 
     public SchematicSetImpl(Set<Schematic> schematics, Selector selector, Map<? extends Nameable, Mutator<?>> schematicModifier, int weight) {
         this.schematics = new ArrayList<>(schematics);
+        Collections.sort(this.schematics);
         this.selector = selector;
         this.schematicModifier = schematicModifier;
         this.weight = weight;
@@ -133,5 +126,27 @@ public class SchematicSetImpl implements SchematicSet {
     @Override
     public void refreshMutator() {
         schematicModifier.values().forEach(ValueProvider::refresh);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        SchematicSetImpl that = (SchematicSetImpl) o;
+
+        if (weight != that.weight) return false;
+        if (!schematics.equals(that.schematics)) return false;
+        if (!selector.equals(that.selector)) return false;
+        return schematicModifier.equals(that.schematicModifier);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = schematics.hashCode();
+        result = 31 * result + selector.hashCode();
+        result = 31 * result + schematicModifier.hashCode();
+        result = 31 * result + weight;
+        return result;
     }
 }

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/config/SchematicSetImpl.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/config/SchematicSetImpl.java
@@ -56,37 +56,6 @@ public class SchematicSetImpl implements SchematicSet {
     }
 
     /**
-     * Get a random schematic from the set
-     *
-     * @return schematic
-     */
-    @Override
-    @Nullable
-    public Schematic getRandomSchematic() {
-        if (schematics.isEmpty()) return null;
-
-        Clipboard clipboard = null;
-
-        Schematic randomSchematic = null;
-        // Search for loadable schematic. Should be likely always the first one.
-        while (clipboard == null && !schematics.isEmpty()) {
-            randomSchematic = schematics.get(randomInt(schematics.size()));
-            try {
-                clipboard = randomSchematic.loadSchematic();
-            } catch (IOException e) {
-                // Silently fail and search for another schematic.
-                SchematicBrushReborn.logger().log(Level.INFO, "Schematic \"" + randomSchematic.path() + "\" does not exist anymore.", e);
-                schematics.remove(randomSchematic);
-            } catch (Exception e) {
-                SchematicBrushReborn.logger().log(Level.SEVERE, "A critical error occured when loading \"" + randomSchematic.path() + "\".", e);
-                schematics.remove(randomSchematic);
-            }
-        }
-
-        return randomSchematic;
-    }
-
-    /**
      * Update a not weighted brush.
      *
      * @param weight weight to set.

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/config/builder/BrushBuilderImpl.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/config/builder/BrushBuilderImpl.java
@@ -11,17 +11,14 @@ import de.eldoria.schematicbrush.brush.SchematicBrushImpl;
 import de.eldoria.schematicbrush.brush.config.BrushSettingsImpl;
 import de.eldoria.schematicbrush.brush.config.BrushSettingsRegistry;
 import de.eldoria.schematicbrush.brush.config.provider.Mutator;
+import de.eldoria.schematicbrush.brush.config.schematics.RandomSelection;
+import de.eldoria.schematicbrush.brush.config.schematics.SchematicSelection;
 import de.eldoria.schematicbrush.brush.config.util.Nameable;
 import de.eldoria.schematicbrush.schematics.SchematicRegistry;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public final class BrushBuilderImpl implements BrushBuilder {
@@ -30,6 +27,7 @@ public final class BrushBuilderImpl implements BrushBuilder {
     private final BrushSettingsRegistry settingsRegistry;
     private final SchematicRegistry schematicRegistry;
     private final Map<Nameable, Mutator<?>> placementModifier;
+    private final SchematicSelection schematicSelection;
 
     BrushBuilderImpl(List<SchematicSetBuilder> schematicSets, Player owner, BrushSettingsRegistry settingsRegistry, SchematicRegistry schematicRegistry, Map<Nameable, Mutator<?>> placementModifier) {
         this.schematicSets = schematicSets;
@@ -37,14 +35,16 @@ public final class BrushBuilderImpl implements BrushBuilder {
         this.settingsRegistry = settingsRegistry;
         this.schematicRegistry = schematicRegistry;
         this.placementModifier = placementModifier;
+        this.schematicSelection = new RandomSelection();
     }
 
-    public BrushBuilderImpl(Player player, BrushSettingsRegistry settingsRegistry, SchematicRegistry schematicRegistry) {
+    public BrushBuilderImpl(Player player, SchematicSelection schematicSelection, BrushSettingsRegistry settingsRegistry, SchematicRegistry schematicRegistry) {
         owner = player;
         schematicSets = new ArrayList<>();
         placementModifier = new HashMap<>();
         this.settingsRegistry = settingsRegistry;
         this.schematicRegistry = schematicRegistry;
+        this.schematicSelection = schematicSelection;
         for (var entry : settingsRegistry.defaultPlacementModifier().entrySet()) {
             setPlacementModifier(entry.getKey(), entry.getValue());
         }
@@ -116,7 +116,7 @@ public final class BrushBuilderImpl implements BrushBuilder {
     @Override
     public SchematicBrush build(Plugin plugin, Player owner) {
         var sets = schematicSets.stream().map(SchematicSetBuilder::build).collect(Collectors.toList());
-        var settings = new BrushSettingsImpl(sets, placementModifier);
+        var settings = new BrushSettingsImpl(schematicSelection, sets, placementModifier);
         return new SchematicBrushImpl(plugin, owner, settings);
     }
 

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/config/schematics/LockedOrderedSelection.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/config/schematics/LockedOrderedSelection.java
@@ -1,0 +1,49 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2021 EldoriaRPG Team and Contributor
+ */
+
+package de.eldoria.schematicbrush.brush.config.schematics;
+
+import de.eldoria.eldoutilities.container.Pair;
+import de.eldoria.eldoutilities.serialization.SerializationUtil;
+import de.eldoria.schematicbrush.brush.SchematicBrush;
+import de.eldoria.schematicbrush.brush.config.SchematicSet;
+import de.eldoria.schematicbrush.schematics.Schematic;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class LockedOrderedSelection extends OrderedSelection {
+
+    public LockedOrderedSelection() {
+    }
+
+    /**
+     * Constructor required by {@link ConfigurationSerializable} in order to deserialize the object.
+     */
+    @SuppressWarnings("unused")
+    public LockedOrderedSelection(Map<String, Object> objectMap) {
+        super(objectMap);
+    }
+
+    @Override
+    @NotNull
+    public Map<String, Object> serialize() {
+        return SerializationUtil.newBuilder()
+                .build();
+    }
+
+    @Override
+    public Optional<Pair<SchematicSet, Schematic>> nextSchematic(SchematicBrush brush, boolean force) {
+        Schematic currSchematic = brush.nextPaste().schematic();
+        SchematicSet currSet = brush.nextPaste().schematicSet();
+        if (!force) {
+            return Optional.of(Pair.of(currSet, currSchematic));
+        }
+        return super.nextSchematic(brush, true);
+    }
+}

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/config/schematics/LockedRandomSelection.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/config/schematics/LockedRandomSelection.java
@@ -1,0 +1,50 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2021 EldoriaRPG Team and Contributor
+ */
+
+package de.eldoria.schematicbrush.brush.config.schematics;
+
+import de.eldoria.eldoutilities.container.Pair;
+import de.eldoria.eldoutilities.serialization.SerializationUtil;
+import de.eldoria.eldoutilities.serialization.TypeResolvingMap;
+import de.eldoria.schematicbrush.brush.SchematicBrush;
+import de.eldoria.schematicbrush.brush.config.SchematicSet;
+import de.eldoria.schematicbrush.schematics.Schematic;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class LockedRandomSelection extends RandomSelection {
+
+    public LockedRandomSelection() {
+    }
+
+    /**
+     * Constructor required by {@link ConfigurationSerializable} in order to deserialize the object.
+     */
+    @SuppressWarnings("unused")
+    public LockedRandomSelection(Map<String, Object> objectMap) {
+        super(objectMap);
+    }
+
+    @Override
+    @NotNull
+    public Map<String, Object> serialize() {
+        return SerializationUtil.newBuilder()
+                .build();
+    }
+
+    @Override
+    public Optional<Pair<SchematicSet, Schematic>> nextSchematic(SchematicBrush brush, boolean force) {
+        Schematic currSchematic = brush.nextPaste().schematic();
+        SchematicSet currSet = brush.nextPaste().schematicSet();
+        if (!force) {
+            return Optional.of(Pair.of(currSet, currSchematic));
+        }
+        return super.nextSchematic(brush, true);
+    }
+}

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/config/schematics/OrderedSelection.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/config/schematics/OrderedSelection.java
@@ -1,0 +1,63 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2021 EldoriaRPG Team and Contributor
+ */
+
+package de.eldoria.schematicbrush.brush.config.schematics;
+
+import de.eldoria.eldoutilities.container.Pair;
+import de.eldoria.eldoutilities.serialization.SerializationUtil;
+import de.eldoria.schematicbrush.brush.SchematicBrush;
+import de.eldoria.schematicbrush.brush.config.SchematicSet;
+import de.eldoria.schematicbrush.schematics.Schematic;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class OrderedSelection implements SchematicSelection {
+
+    public OrderedSelection() {
+    }
+
+    /**
+     * Constructor required by {@link ConfigurationSerializable} in order to deserialize the object.
+     */
+    @SuppressWarnings("unused")
+    public OrderedSelection(Map<String, Object> objectMap) {
+    }
+
+    @Override
+    public Optional<Pair<SchematicSet, Schematic>> nextSchematic(SchematicBrush brush, boolean force) {
+        Schematic currSchematic = brush.nextPaste().schematic();
+        SchematicSet currSet = brush.nextPaste().schematicSet();
+        List<Schematic> currSchematics = currSet.schematics();
+        List<SchematicSet> schematicSets = brush.settings().schematicSets();
+        var nextSet = currSet;
+        var nextSchematic = currSchematic;
+
+        if (currSchematics.indexOf(currSchematic) + 1 >= currSchematics.size()) {
+            if (schematicSets.indexOf(currSet) + 1 >= schematicSets.size()) {
+                nextSet = schematicSets.get(0);
+            } else {
+                nextSet = schematicSets.get(schematicSets.indexOf(currSet) + 1);
+            }
+            nextSchematic = nextSet.schematics().get(0);
+        } else {
+            nextSchematic = nextSet.schematics().get(currSchematics.indexOf(currSchematic) + 1);
+        }
+
+        return Optional.of(Pair.of(nextSet, nextSchematic));
+    }
+
+    @NotNull
+    @Override
+    public Map<String, Object> serialize() {
+        return SerializationUtil.newBuilder()
+                .build();
+    }
+}

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/config/schematics/RandomSelection.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/config/schematics/RandomSelection.java
@@ -1,0 +1,108 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2021 EldoriaRPG Team and Contributor
+ */
+
+package de.eldoria.schematicbrush.brush.config.schematics;
+
+import com.sk89q.worldedit.extent.clipboard.Clipboard;
+import de.eldoria.eldoutilities.container.Pair;
+import de.eldoria.eldoutilities.messages.MessageSender;
+import de.eldoria.eldoutilities.serialization.SerializationUtil;
+import de.eldoria.schematicbrush.SchematicBrushReborn;
+import de.eldoria.schematicbrush.brush.SchematicBrush;
+import de.eldoria.schematicbrush.brush.config.BrushSettings;
+import de.eldoria.schematicbrush.brush.config.SchematicSet;
+import de.eldoria.schematicbrush.schematics.Schematic;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Level;
+
+public class RandomSelection implements SchematicSelection {
+
+    public RandomSelection() {
+    }
+
+    /**
+     * Constructor required by {@link ConfigurationSerializable} in order to deserialize the object.
+     */
+    @SuppressWarnings("unused")
+    public RandomSelection(Map<String, Object> objectMap) {
+    }
+
+    @Override
+    public Optional<Pair<SchematicSet, Schematic>> nextSchematic(SchematicBrush brush, boolean force) {
+        var set = getRandomSchematicSet(brush.settings());
+        var schematic = getRandomSchematic(set);
+        if (schematic == null) {
+            return Optional.empty();
+        }
+
+        var newSchematic = getRandomSchematic(set);
+        while (newSchematic == schematic) {
+            newSchematic = getRandomSchematic(set);
+            if (set.schematics().isEmpty()) {
+                MessageSender.getPluginMessageSender(SchematicBrushReborn.class).sendError(brush.brushOwner(),
+                        "No valid schematic remaining in current set");
+                return Optional.empty();
+            }
+            if (newSchematic == null) continue;
+            if (set.schematics().size() <= 1) break;
+        }
+
+        return Optional.of(Pair.of(set, schematic));
+    }
+
+    private SchematicSet getRandomSchematicSet(BrushSettings settings) {
+        var random = randomInt(settings.totalWeight());
+        List<SchematicSet> schematicSets = settings.schematicSets();
+
+        var count = 0;
+        for (var brush : schematicSets) {
+            if (count + brush.weight() > random) {
+                return brush;
+            }
+            count += brush.weight();
+        }
+        return schematicSets.get(schematicSets.size() - 1);
+    }
+
+    private Schematic getRandomSchematic(SchematicSet set) {
+        List<Schematic> schematics = set.schematics();
+        if (schematics.isEmpty()) return null;
+
+        Clipboard clipboard = null;
+
+        Schematic randomSchematic = null;
+        // Search for loadable schematic. Should be likely always the first one.
+        while (clipboard == null && !schematics.isEmpty()) {
+            randomSchematic = schematics.get(randomInt(schematics.size()));
+            try {
+                clipboard = randomSchematic.loadSchematic();
+            } catch (IOException e) {
+                // Silently fail and search for another schematic.
+                SchematicBrushReborn.logger().log(Level.INFO, "Schematic \"" + randomSchematic.path() + "\" does not exist anymore.", e);
+                schematics.remove(randomSchematic);
+            } catch (Exception e) {
+                SchematicBrushReborn.logger().log(Level.SEVERE, "A critical error occured when loading \"" + randomSchematic.path() + "\".", e);
+                schematics.remove(randomSchematic);
+            }
+        }
+
+        return randomSchematic;
+    }
+
+    @NotNull
+    @Override
+    public Map<String, Object> serialize() {
+        return SerializationUtil.newBuilder()
+                .build();
+    }
+}

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/history/BrushHistoryImpl.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/history/BrushHistoryImpl.java
@@ -1,0 +1,40 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2021 EldoriaRPG Team and Contributor
+ */
+
+package de.eldoria.schematicbrush.brush.history;
+
+import de.eldoria.eldoutilities.container.Pair;
+import de.eldoria.schematicbrush.brush.config.SchematicSet;
+import de.eldoria.schematicbrush.schematics.Schematic;
+
+import java.util.Optional;
+import java.util.Stack;
+
+public class BrushHistoryImpl implements BrushHistory {
+    private final Stack<Pair<SchematicSet, Schematic>> history = new Stack<>();
+    private final int size;
+
+    public BrushHistoryImpl(int size) {
+        this.size = size;
+    }
+
+    @Override
+    public Optional<Pair<SchematicSet, Schematic>> previous() {
+        if (history.empty()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(history.pop());
+    }
+
+    @Override
+    public void push(SchematicSet set, Schematic schematic) {
+        // Only push if the new item is different to the head of the stack
+        if (history.peek().equals(Pair.of(set, schematic))) return;
+        history.push(Pair.of(set, schematic));
+        // keep size
+        if (history.size() >= size) history.removeElementAt(history.size() - 1);
+    }
+}

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/history/BrushHistoryImpl.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/history/BrushHistoryImpl.java
@@ -32,7 +32,7 @@ public class BrushHistoryImpl implements BrushHistory {
     @Override
     public void push(SchematicSet set, Schematic schematic) {
         // Only push if the new item is different to the head of the stack
-        if (history.peek().equals(Pair.of(set, schematic))) return;
+        if (!history.empty() && history.peek().equals(Pair.of(set, schematic))) return;
         history.push(Pair.of(set, schematic));
         // keep size
         if (history.size() >= size) history.removeElementAt(history.size() - 1);

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/provider/SchematicSelectionProviderImpl.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/provider/SchematicSelectionProviderImpl.java
@@ -1,0 +1,115 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2021 EldoriaRPG Team and Contributor
+ */
+
+package de.eldoria.schematicbrush.brush.provider;
+
+import de.eldoria.eldoutilities.commands.command.util.Arguments;
+import de.eldoria.eldoutilities.commands.exceptions.CommandException;
+import de.eldoria.schematicbrush.brush.config.provider.SchematicSelectionProvider;
+import de.eldoria.schematicbrush.brush.config.schematics.*;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.bukkit.entity.Player;
+
+import java.util.Collections;
+import java.util.List;
+
+public abstract class SchematicSelectionProviderImpl extends SchematicSelectionProvider {
+    /**
+     * Create a new settings provider
+     *
+     * @param clazz which is returned by the provider
+     * @param name  name. Must be unique inside the provider.
+     */
+    public SchematicSelectionProviderImpl(Class<? extends ConfigurationSerializable> clazz, String name) {
+        super(clazz, name);
+    }
+
+    public static final SchematicSelectionProvider LOCKED_ORDERED_SELECTION = new SchematicSelectionProviderImpl(LockedOrderedSelection.class, "locked_ordered") {
+        @Override
+        public SchematicSelection parse(Arguments args) throws CommandException {
+            return new LockedOrderedSelection();
+        }
+
+        @Override
+        public List<String> complete(Arguments args, Player player) throws CommandException {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public SchematicSelection defaultSetting() {
+            return new LockedOrderedSelection();
+        }
+
+        @Override
+        public String description() {
+            return "A selector which only skips to the next schematic when prompted. Next schematic will be the next in the order.";
+        }
+    };
+
+    public static final SchematicSelectionProvider LOCKED_RANDOM_SELECTION = new SchematicSelectionProviderImpl(LockedRandomSelection.class, "locked_random") {
+        @Override
+        public SchematicSelection parse(Arguments args) throws CommandException {
+            return new LockedRandomSelection();
+        }
+
+        @Override
+        public List<String> complete(Arguments args, Player player) throws CommandException {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public SchematicSelection defaultSetting() {
+            return new LockedRandomSelection();
+        }
+
+        @Override
+        public String description() {
+            return "A selector which only skips to the next schematic when prompted. Next schematic will be random.";
+        }
+    };
+    public static final SchematicSelectionProvider RANDOM_SELECTION = new SchematicSelectionProviderImpl(RandomSelection.class, "random") {
+        @Override
+        public SchematicSelection parse(Arguments args) throws CommandException {
+            return new RandomSelection();
+        }
+
+        @Override
+        public List<String> complete(Arguments args, Player player) throws CommandException {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public SchematicSelection defaultSetting() {
+            return new RandomSelection();
+        }
+
+        @Override
+        public String description() {
+            return "A selector which skips to the next schematic.";
+        }
+    };
+    public static final SchematicSelectionProvider ORDERED_SELECTION = new SchematicSelectionProviderImpl(OrderedSelection.class, "ordered") {
+        @Override
+        public SchematicSelection parse(Arguments args) throws CommandException {
+            return new RandomSelection();
+        }
+
+        @Override
+        public List<String> complete(Arguments args, Player player) throws CommandException {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public SchematicSelection defaultSetting() {
+            return new RandomSelection();
+        }
+
+        @Override
+        public String description() {
+            return "A selector which skips to the next schematic in the current order.";
+        }
+    };
+}

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/commands/Modify.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/commands/Modify.java
@@ -1,0 +1,33 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2021 EldoriaRPG Team and Contributor
+ */
+
+package de.eldoria.schematicbrush.commands;
+
+import de.eldoria.eldoutilities.commands.command.AdvancedCommand;
+import de.eldoria.eldoutilities.commands.command.CommandMeta;
+import de.eldoria.schematicbrush.brush.config.BrushSettingsRegistry;
+import de.eldoria.schematicbrush.commands.modify.Next;
+import de.eldoria.schematicbrush.commands.modify.Previous;
+import de.eldoria.schematicbrush.commands.modify.Selection;
+import de.eldoria.schematicbrush.util.Permissions;
+import org.bukkit.plugin.Plugin;
+
+
+/**
+ * Brush to create and modify brush presets.
+ */
+public class Modify extends AdvancedCommand {
+    public Modify(Plugin plugin, BrushSettingsRegistry registry) {
+        super(plugin);
+        meta(CommandMeta.builder("sbrm")
+                .withPermission(Permissions.Brush.USE)
+                .buildSubCommands((cmds, builder) -> {
+                    cmds.add(new Next(plugin));
+                    cmds.add(new Previous(plugin));
+                    cmds.add(new Selection(registry, plugin));
+                }).build());
+    }
+}

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/commands/brush/Bind.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/commands/brush/Bind.java
@@ -49,8 +49,8 @@ public class Bind extends AdvancedCommand implements IPlayerTabExecutor {
             return;
         }
 
-        var schematicCount = brush.getSettings().getSchematicCount();
-        var setcount = brush.getSettings().schematicSets().size();
+        var schematicCount = brush.settings().getSchematicCount();
+        var setcount = brush.settings().schematicSets().size();
         var message = String.format("<%s>Brush bound. Using <%s>%s<%s> Schematics in <%s>%s<%s> Sets. <%s><click:run_command:'/sbr'>[Edit]</click>",
                 Colors.NEUTRAL, Colors.VALUE, schematicCount, Colors.NEUTRAL, Colors.VALUE, setcount, Colors.NEUTRAL, Colors.CHANGE);
         messageBlocker.unblockPlayer(player).thenRun(() -> audiences.sender(player).sendMessage(miniMessage.deserialize(message)));

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/commands/brush/Sessions.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/commands/brush/Sessions.java
@@ -12,6 +12,7 @@ import de.eldoria.schematicbrush.brush.config.BrushSettingsRegistry;
 import de.eldoria.schematicbrush.brush.config.builder.BrushBuilder;
 import de.eldoria.schematicbrush.brush.config.builder.BrushBuilderImpl;
 import de.eldoria.schematicbrush.brush.config.builder.BuildUtil;
+import de.eldoria.schematicbrush.brush.config.schematics.RandomSelection;
 import de.eldoria.schematicbrush.schematics.SchematicRegistry;
 import de.eldoria.schematicbrush.util.Colors;
 import de.eldoria.schematicbrush.util.Permissions;
@@ -23,7 +24,6 @@ import org.bukkit.plugin.Plugin;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -57,7 +57,7 @@ public class Sessions {
     private BrushBuilder getOrCreateBuilder(Player player) {
         return WorldEditBrush.getSchematicBrush(player)
                 .map(brush -> brush.toBuilder(registry, schematicRegistry))
-                .orElse(new BrushBuilderImpl(player, registry, schematicRegistry));
+                .orElse(new BrushBuilderImpl(player, new RandomSelection(), registry, schematicRegistry));
     }
 
     public void showBrush(Player player) {

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/commands/modify/Next.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/commands/modify/Next.java
@@ -1,0 +1,41 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2021 EldoriaRPG Team and Contributor
+ */
+
+package de.eldoria.schematicbrush.commands.modify;
+
+import de.eldoria.eldoutilities.commands.command.AdvancedCommand;
+import de.eldoria.eldoutilities.commands.command.CommandMeta;
+import de.eldoria.eldoutilities.commands.command.util.Arguments;
+import de.eldoria.eldoutilities.commands.command.util.CommandAssertions;
+import de.eldoria.eldoutilities.commands.exceptions.CommandException;
+import de.eldoria.eldoutilities.commands.executor.IPlayerTabExecutor;
+import de.eldoria.eldoutilities.messages.MessageChannel;
+import de.eldoria.eldoutilities.messages.MessageType;
+import de.eldoria.schematicbrush.brush.SchematicBrush;
+import de.eldoria.schematicbrush.util.WorldEditBrush;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
+
+public class Next extends AdvancedCommand implements IPlayerTabExecutor {
+    public Next(Plugin plugin) {
+        super(plugin, CommandMeta.builder("next")
+                .build());
+    }
+
+    @Override
+    public void onCommand(@NotNull Player player, @NotNull String alias, @NotNull Arguments args) throws CommandException {
+        Optional<SchematicBrush> schematicBrush = WorldEditBrush.getSchematicBrush(player);
+        CommandAssertions.isTrue(schematicBrush.isPresent(), "You are not holding a schematic brush");
+        if (schematicBrush.get().nextPaste().nextSchematic()) {
+            messageSender().send(MessageChannel.ACTION_BAR, MessageType.NORMAL, player, "§2Skipped Schematic.");
+        } else {
+            messageSender().send(MessageChannel.ACTION_BAR, MessageType.ERROR, player, "The brush contains only 1 schematic");
+        }
+    }
+}

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/commands/modify/Previous.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/commands/modify/Previous.java
@@ -1,0 +1,41 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2021 EldoriaRPG Team and Contributor
+ */
+
+package de.eldoria.schematicbrush.commands.modify;
+
+import de.eldoria.eldoutilities.commands.command.AdvancedCommand;
+import de.eldoria.eldoutilities.commands.command.CommandMeta;
+import de.eldoria.eldoutilities.commands.command.util.Arguments;
+import de.eldoria.eldoutilities.commands.command.util.CommandAssertions;
+import de.eldoria.eldoutilities.commands.exceptions.CommandException;
+import de.eldoria.eldoutilities.commands.executor.IPlayerTabExecutor;
+import de.eldoria.eldoutilities.messages.MessageChannel;
+import de.eldoria.eldoutilities.messages.MessageType;
+import de.eldoria.schematicbrush.brush.SchematicBrush;
+import de.eldoria.schematicbrush.util.WorldEditBrush;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Optional;
+
+public class Previous extends AdvancedCommand implements IPlayerTabExecutor {
+    public Previous(Plugin plugin) {
+        super(plugin, CommandMeta.builder("previous")
+                .build());
+    }
+
+    @Override
+    public void onCommand(@NotNull Player player, @NotNull String alias, @NotNull Arguments args) throws CommandException {
+        Optional<SchematicBrush> schematicBrush = WorldEditBrush.getSchematicBrush(player);
+        CommandAssertions.isTrue(schematicBrush.isPresent(), "You are not holding a schematic brush");
+        if (schematicBrush.get().nextPaste().previousSchematic()) {
+            messageSender().send(MessageChannel.ACTION_BAR, MessageType.NORMAL, player, "§2Previous Schematic");
+        } else {
+            messageSender().send(MessageChannel.ACTION_BAR, MessageType.ERROR, player, "The history is empty");
+        }
+    }
+}

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/commands/modify/Selection.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/commands/modify/Selection.java
@@ -1,0 +1,52 @@
+/*
+ *     SPDX-License-Identifier: AGPL-3.0-only
+ *
+ *     Copyright (C) 2021 EldoriaRPG Team and Contributor
+ */
+
+package de.eldoria.schematicbrush.commands.modify;
+
+import de.eldoria.eldoutilities.commands.command.AdvancedCommand;
+import de.eldoria.eldoutilities.commands.command.CommandMeta;
+import de.eldoria.eldoutilities.commands.command.util.Arguments;
+import de.eldoria.eldoutilities.commands.command.util.CommandAssertions;
+import de.eldoria.eldoutilities.commands.exceptions.CommandException;
+import de.eldoria.eldoutilities.commands.executor.IPlayerTabExecutor;
+import de.eldoria.eldoutilities.messages.MessageChannel;
+import de.eldoria.eldoutilities.messages.MessageType;
+import de.eldoria.schematicbrush.brush.SchematicBrush;
+import de.eldoria.schematicbrush.brush.config.BrushSettingsRegistry;
+import de.eldoria.schematicbrush.brush.config.schematics.SchematicSelection;
+import de.eldoria.schematicbrush.util.WorldEditBrush;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Optional;
+
+public class Selection extends AdvancedCommand implements IPlayerTabExecutor {
+    private final BrushSettingsRegistry registry;
+
+    public Selection(BrushSettingsRegistry registry, Plugin plugin) {
+        super(plugin, CommandMeta.builder("selection")
+                .addUnlocalizedArgument("mode", true)
+                .build());
+        this.registry = registry;
+    }
+
+    @Override
+    public void onCommand(@NotNull Player player, @NotNull String alias, @NotNull Arguments args) throws CommandException {
+        Optional<SchematicBrush> schematicBrush = WorldEditBrush.getSchematicBrush(player);
+        CommandAssertions.isTrue(schematicBrush.isPresent(), "You are not holding a schematic brush");
+        SchematicSelection schematicSelection = registry.parseSchematicSelection(args);
+        schematicBrush.get().settings().schematicSelection(schematicSelection);
+        messageSender().send(MessageChannel.CHAT, MessageType.NORMAL, player, "Schematic selection changed.");
+    }
+
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull Player player, @NotNull String alias, @NotNull Arguments args) throws CommandException {
+        return registry.completeSchematicSelection(args, player);
+    }
+}

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/listener/BrushModifier.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/listener/BrushModifier.java
@@ -59,7 +59,7 @@ public class BrushModifier implements Listener {
                 messageSender.send(MessageChannel.ACTION_BAR, MessageType.ERROR, event.getPlayer(), "Offset is not shiftable.");
             }
         } else {
-            if (schematicBrush.get().nextPaste().shiftSchematic()) {
+            if (schematicBrush.get().nextPaste().nextSchematic()) {
                 messageSender.send(MessageChannel.ACTION_BAR, MessageType.NORMAL, event.getPlayer(), "§2Skipped Schematic.");
             } else {
                 messageSender.send(MessageChannel.ACTION_BAR, MessageType.ERROR, event.getPlayer(), "The set only contains 1 schematic");

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/rendering/RenderService.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/rendering/RenderService.java
@@ -156,8 +156,8 @@ public class RenderService implements Runnable, Listener {
             return;
         }
 
-        var includeAir = (boolean) brush.getSettings().getMutator(PlacementModifier.INCLUDE_AIR).value();
-        var replaceAll = (boolean) brush.getSettings().getMutator(PlacementModifier.REPLACE_ALL).value();
+        var includeAir = (boolean) brush.settings().getMutator(PlacementModifier.INCLUDE_AIR).value();
+        var replaceAll = (boolean) brush.settings().getMutator(PlacementModifier.REPLACE_ALL).value();
 
         if (includeAir && replaceAll && brush.nextPaste().schematic().size() > general.maxRenderSize()) {
             resolveChanges(player);

--- a/schematicbrushreborn-core/src/test/java/de/eldoria/schematicbrush/storage/TestBrush.java
+++ b/schematicbrushreborn-core/src/test/java/de/eldoria/schematicbrush/storage/TestBrush.java
@@ -12,6 +12,7 @@ import de.eldoria.eldoutilities.serialization.wrapper.MapEntry;
 import de.eldoria.eldoutilities.serialization.wrapper.YamlContainer;
 import de.eldoria.schematicbrush.SchematicBrushRebornImpl;
 import de.eldoria.schematicbrush.brush.config.builder.BrushBuilderImpl;
+import de.eldoria.schematicbrush.brush.config.schematics.RandomSelection;
 import de.eldoria.schematicbrush.storage.brush.Brush;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.serialization.ConfigurationSerialization;
@@ -41,7 +42,7 @@ public class TestBrush {
     @Test
     public void testSerialization() throws IOException, InvalidConfigurationException {
         var someone = server.addPlayer("Someone");
-        var brushBuilder = new BrushBuilderImpl(someone, load.brushSettingsRegistry(), load.schematics());
+        var brushBuilder = new BrushBuilderImpl(someone, new RandomSelection(), load.brushSettingsRegistry(), load.schematics());
         var some = new Brush("some", brushBuilder);
 
         //This is only required for the sake of unit testing.


### PR DESCRIPTION
*Schematic history*
Adds a brush history to each schematic brush. this history saves previously used schematics on this brush.

*Add commands to go back and forth*
`/sbrm next` and `/sbrm previous` allow you to go backwards and forwards through your schematics. While the previous will be always the previously selected schematic the next command will bring up the next schematic based on the selection mode you choose. Using the next command is equal to using the F key (Or the swap hand hotkey)

*Add selection modes for schematics*
As of today the next schematic was a random schematic chosen from a random set. From today on you can use `/sbrm selection <mode>` to chose a selection mode based on your preference. There are 4 different selection modes:
- **random**: That's the default and what you are used to. The next schematic will be always a random schematic from any set.
- **Ordered**: This mode will choose the next schematic in your current set after the current schematic or the first schematic of the next set if the end is reached. If you only have one set the first schematic of your current set will be chosen. Schematics inside a set are ordered by name and their numbers if they have some.
- **Locked Random**: This mode will always use the same schematic unless you press the f key or use the /sbrm next command to switch to another random schematic
- **Locked ordered**: The same like locked random except that the next schematic is chosen by the order like the ordered selection