### PR TITLE
Modify the preview command to allow toggling of the state of rendering

### DIFF
--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/commands/settings/preview/Enable.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/commands/settings/preview/Enable.java
@@ -25,20 +25,17 @@ public class Enable extends AdvancedCommand implements IPlayerTabExecutor {
 
     public Enable(Plugin plugin, RenderService renderService) {
         super(plugin, CommandMeta.builder("enable")
-                .addUnlocalizedArgument("state", true)
+                .addUnlocalizedArgument("state", false)
                 .build());
         this.renderService = renderService;
     }
 
     @Override
     public void onCommand(@NotNull Player player, @NotNull String alias, @NotNull Arguments args) throws CommandException {
-        var state = args.asBoolean(0);
+
+        boolean state = args.isEmpty() ? !renderService.getState(player) : args.asBoolean(0);
         renderService.setState(player, state);
-        if (state) {
-            messageSender().sendMessage(player, "Preview active.");
-        } else {
-            messageSender().sendMessage(player, "Preview disabled.");
-        }
+        messageSender().sendMessage(player, state ? "Preview active." : "Preview disabled.");
     }
 
     @Override

--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/rendering/RenderService.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/rendering/RenderService.java
@@ -211,6 +211,15 @@ public class RenderService implements Runnable, Listener {
         }
     }
 
+    /**
+     * @param player
+     * Returns true if preview is active.
+     * Returns false if preview is not active.
+     */
+    public boolean getState(Player player) {
+        return players.contains(player);
+    }
+
     private Optional<RenderSink> getSubscription(Player player) {
         return Optional.ofNullable(subscription.get(player.getUniqueId()));
     }


### PR DESCRIPTION
Simplified the Enable command of Schematic preview.

Tested and is working on server.

**Additions**
   + Allow no arguments to be passed to command and have it toggle to opposite

**Removed**
   - Removed required argument of state