### PR TITLE
♻️ Avoid unnecessary allocation in PlacementProvider

### DIFF
--- a/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/provider/PlacementProvider.java
+++ b/schematicbrushreborn-core/src/main/java/de/eldoria/schematicbrush/brush/provider/PlacementProvider.java
@@ -56,7 +56,7 @@ public abstract class PlacementProvider extends ModifierProvider {
 
     @Override
     public Mutator<?> defaultSetting() {
-        return new Drop();
+        return drop;
     }
 
     @Override


### PR DESCRIPTION
- Return existing static placement instances (bottom/drop/middle/raise/top/original) instead of creating new objects on each call to avoid allocations and reduce GC pressure (performance ⚡️).

Originally I planned to make other change e.g. adding a default too which then was dropped and will be made in another pr once i have time. The way i handled it was quite bad. 